### PR TITLE
Add editor integration to open generated code files

### DIFF
--- a/quantcoder/config.py
+++ b/quantcoder/config.py
@@ -30,6 +30,7 @@ class UIConfig:
     theme: str = "monokai"
     auto_approve: bool = False
     show_token_usage: bool = True
+    editor: str = "zed"  # Editor for --open-in-editor flag (zed, code, vim, etc.)
 
 
 @dataclass
@@ -112,6 +113,7 @@ class Config:
                 "theme": self.ui.theme,
                 "auto_approve": self.ui.auto_approve,
                 "show_token_usage": self.ui.show_token_usage,
+                "editor": self.ui.editor,
             },
             "tools": {
                 "enabled_tools": self.tools.enabled_tools,

--- a/quantcoder/editor.py
+++ b/quantcoder/editor.py
@@ -1,0 +1,62 @@
+"""Editor integration utilities for QuantCoder CLI."""
+
+import subprocess
+import shutil
+import logging
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+def open_in_editor(file_path: str, editor: str = "zed") -> bool:
+    """
+    Open a file in the specified editor.
+
+    Args:
+        file_path: Path to the file to open
+        editor: Editor command (zed, code, vim, nvim, etc.)
+
+    Returns:
+        True if editor launched successfully, False otherwise
+    """
+    path = Path(file_path)
+
+    if not path.exists():
+        logger.error(f"File not found: {file_path}")
+        return False
+
+    # Check if editor is available
+    editor_path = shutil.which(editor)
+    if not editor_path:
+        logger.error(f"Editor '{editor}' not found in PATH")
+        return False
+
+    try:
+        # Launch editor (non-blocking)
+        subprocess.Popen(
+            [editor, str(path)],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True
+        )
+        logger.info(f"Opened {file_path} in {editor}")
+        return True
+    except Exception as e:
+        logger.error(f"Failed to open editor: {e}")
+        return False
+
+
+def get_editor_display_name(editor: str) -> str:
+    """Get a friendly display name for the editor."""
+    editor_names = {
+        "zed": "Zed",
+        "code": "VS Code",
+        "vim": "Vim",
+        "nvim": "Neovim",
+        "nano": "Nano",
+        "subl": "Sublime Text",
+        "atom": "Atom",
+        "emacs": "Emacs",
+    }
+    return editor_names.get(editor, editor)


### PR DESCRIPTION
## Summary
This PR adds the ability to automatically open generated QuantConnect code files in the user's preferred editor. Users can now use the `--open-in-editor` flag with the `generate` command to launch the code in their configured editor.

## Key Changes
- **New CLI options**: Added `--open-in-editor` flag and `--editor` option to the `generate` command
  - `--open-in-editor`: Opens the generated code file in an editor after successful generation
  - `--editor`: Allows overriding the default editor (e.g., `zed`, `code`, `vim`)
  
- **New editor module** (`quantcoder/editor.py`):
  - `open_in_editor()`: Launches a file in the specified editor with proper error handling
  - `get_editor_display_name()`: Provides friendly display names for common editors
  
- **Configuration updates**:
  - Added `editor` field to `UIConfig` with default value of `"zed"`
  - Updated config serialization to include the new editor setting

- **Enhanced user experience**:
  - Provides feedback when editor is successfully opened
  - Shows helpful warning if editor is not installed
  - Non-blocking editor launch using subprocess

## Implementation Details
- Editor detection uses `shutil.which()` to verify editor availability in PATH
- Editor process is launched non-blocking with `subprocess.Popen()` and `start_new_session=True` to prevent blocking the CLI
- Comprehensive error handling for missing files and unavailable editors
- Supports common editors: Zed, VS Code, Vim, Neovim, Nano, Sublime Text, Atom, and Emacs