### PR TITLE
Add Ollama local LLM provider support

### DIFF
--- a/quantcoder/config.py
+++ b/quantcoder/config.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 @dataclass
 class ModelConfig:
     """Configuration for the AI model."""
-    provider: str = "anthropic"  # anthropic, mistral, deepseek, openai
+    provider: str = "anthropic"  # anthropic, mistral, deepseek, openai, ollama
     model: str = "claude-sonnet-4-5-20250929"
     temperature: float = 0.5
     max_tokens: int = 3000
@@ -22,6 +22,10 @@ class ModelConfig:
     coordinator_provider: str = "anthropic"  # Best for orchestration
     code_provider: str = "mistral"  # Devstral for code generation
     risk_provider: str = "anthropic"  # Sonnet for nuanced risk decisions
+
+    # Local LLM (Ollama) settings
+    ollama_base_url: str = "http://localhost:11434/v1"  # Ollama API endpoint
+    ollama_model: str = "llama3.2"  # Default Ollama model (codellama, qwen2.5-coder, etc.)
 
 
 @dataclass
@@ -108,6 +112,8 @@ class Config:
                 "model": self.model.model,
                 "temperature": self.model.temperature,
                 "max_tokens": self.model.max_tokens,
+                "ollama_base_url": self.model.ollama_base_url,
+                "ollama_model": self.model.ollama_model,
             },
             "ui": {
                 "theme": self.ui.theme,


### PR DESCRIPTION
## Summary
This PR adds support for Ollama, enabling users to run large language models locally without API costs. The implementation includes a new `OllamaProvider` class and integrates it into the existing LLM factory pattern.

## Key Changes
- **New OllamaProvider class** (`quantcoder/llm/providers.py`):
  - Implements local LLM inference using Ollama's OpenAI-compatible API
  - Supports multiple models (llama3.2, codellama, qwen2.5-coder, etc.)
  - Configurable base URL for custom Ollama deployments
  - Async chat completion support consistent with other providers

- **Updated LLMFactory** (`quantcoder/llm/providers.py`):
  - Added "ollama" to PROVIDERS registry
  - Made `api_key` parameter optional (not required for Ollama)
  - Added `base_url` parameter to support local provider configuration
  - Updated factory method to handle Ollama's different initialization requirements

- **Configuration updates** (`quantcoder/config.py`):
  - Added `ollama_base_url` and `ollama_model` fields to `ModelConfig`
  - Updated provider comment to include "ollama" option
  - Exported Ollama settings in `to_dict()` method for configuration serialization

- **Bug fix**: Fixed typo in LLMFactory.PROVIDERS ("Mistral Provider" → "MistralProvider")

## Implementation Details
- Ollama provider uses OpenAI's AsyncOpenAI client with a custom base URL, leveraging Ollama's OpenAI-compatible API endpoint
- Default configuration points to `http://localhost:11434/v1` with `llama3.2` model
- API key is set to "ollama" (required by OpenAI client but unused by Ollama)
- Maintains consistency with existing provider interface for seamless integration