### PR TITLE
Add automated backtest workflow with Notion integration

### DIFF
--- a/docs/QUANTCODER_GUIDE.md
+++ b/docs/QUANTCODER_GUIDE.md
@@ -1,0 +1,616 @@
+# QuantCoder CLI - Complete Guide
+
+> AI-powered CLI for transforming research papers into QuantConnect trading algorithms
+
+---
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Installation & Setup](#installation--setup)
+3. [Two Workflows](#two-workflows)
+4. [CLI Commands Reference](#cli-commands-reference)
+5. [Configuration](#configuration)
+6. [Logging & Monitoring](#logging--monitoring)
+7. [Deep Search with Tavily](#deep-search-with-tavily)
+8. [Strategy Evolution](#strategy-evolution)
+9. [Notion Integration](#notion-integration)
+10. [Environment Variables](#environment-variables)
+
+---
+
+## Overview
+
+QuantCoder is a conversational CLI tool that automates the research-to-algorithm pipeline:
+
+```
+Research Paper → Summary → QuantConnect Code → Backtest → Evolution → Publish
+```
+
+### Key Features
+
+| Feature | Description |
+|---------|-------------|
+| **Paper Discovery** | Search academic papers via CrossRef or semantic deep search (Tavily) |
+| **Multi-Article Workflow** | Combine insights from multiple papers into consolidated strategies |
+| **Code Generation** | Generate QuantConnect-compatible Python algorithms |
+| **Auto-Refinement** | Automatically fix compilation errors with LLM assistance |
+| **Backtesting** | Run backtests on QuantConnect cloud |
+| **Evolution** | AlphaEvolve-inspired strategy optimization |
+| **Scheduling** | Automated daily/weekly pipeline runs |
+| **Notion Publishing** | Publish successful strategies as articles |
+| **Comprehensive Logging** | Structured logs with rotation and alerting |
+
+---
+
+## Installation & Setup
+
+### 1. Clone and Install
+
+```bash
+git clone https://github.com/SL-Mar/quantcoder-cli.git
+cd quantcoder-cli
+pip install -e .
+```
+
+### 2. Configure API Keys
+
+```bash
+# Interactive setup
+quantcoder schedule config --show
+
+# Set individual keys
+quantcoder schedule config --notion-key secret_xxx --notion-db abc123
+quantcoder schedule config --tavily-key tvly-xxx
+```
+
+Or manually create `~/.quantcoder/.env`:
+
+```env
+# Required
+ANTHROPIC_API_KEY=sk-ant-xxx
+# or
+OPENAI_API_KEY=sk-xxx
+
+# QuantConnect (for backtesting)
+QUANTCONNECT_API_KEY=xxx
+QUANTCONNECT_USER_ID=xxx
+
+# Optional integrations
+NOTION_API_KEY=secret_xxx
+NOTION_DATABASE_ID=xxx
+TAVILY_API_KEY=tvly-xxx
+
+# Alerting (optional)
+QUANTCODER_WEBHOOK_URL=https://hooks.slack.com/...
+```
+
+### 3. Verify Setup
+
+```bash
+quantcoder --help
+quantcoder schedule config --show
+```
+
+---
+
+## Two Workflows
+
+### Workflow 1: Spot Generation (Manual/Interactive)
+
+For ad-hoc strategy generation with full control over each step.
+
+```bash
+# Step 1: Search for papers
+quantcoder search "momentum trading strategies" --num 5
+
+# Or use deep semantic search
+quantcoder search "mean reversion with machine learning" --deep
+
+# Step 2: Download a paper
+quantcoder download 1 2 3
+
+# Step 3: Summarize and extract strategy
+quantcoder summarize 1
+
+# Step 4: Generate code (with optional backtest and evolution)
+quantcoder generate 1 --backtest --evolve --gens 5
+```
+
+#### Spot Generation Options
+
+```bash
+quantcoder generate <SUMMARY_ID> [OPTIONS]
+
+Options:
+  --max-attempts INT     Maximum refinement attempts (default: 6)
+  --open-in-editor       Open generated code in editor
+  --editor TEXT          Editor to use (zed, code, vim)
+  --backtest             Run backtest on QuantConnect
+  --min-sharpe FLOAT     Min Sharpe to keep algo (default: 0.5)
+  --start-date TEXT      Backtest start date (default: 2020-01-01)
+  --end-date TEXT        Backtest end date (default: 2024-01-01)
+  --evolve               Evolve strategy after backtest passes
+  --gens INT             Evolution generations (default: 5)
+  --variants INT         Variants per generation (default: 3)
+```
+
+### Workflow 2: Batch Mode (Automated/Scheduled)
+
+For hands-off automated strategy discovery and generation.
+
+#### One-Time Run
+
+```bash
+# Run the full pipeline once
+quantcoder schedule run
+
+# With custom options
+quantcoder schedule run \
+  --queries "momentum,mean reversion,factor investing" \
+  --min-sharpe 1.0 \
+  --max-strategies 10 \
+  --evolve --gens 5
+```
+
+#### Scheduled Runs
+
+```bash
+# Start daily schedule at 6 AM
+quantcoder schedule start --interval daily --hour 6
+
+# Start weekly schedule on Monday at 9 AM
+quantcoder schedule start --interval weekly --day mon --hour 9
+
+# With evolution enabled
+quantcoder schedule start --interval daily --evolve --gens 5 --run-now
+```
+
+#### Check Status
+
+```bash
+quantcoder schedule status
+```
+
+---
+
+## CLI Commands Reference
+
+### Main Commands
+
+| Command | Description |
+|---------|-------------|
+| `quantcoder` | Launch interactive chat mode |
+| `quantcoder search <query>` | Search for academic papers |
+| `quantcoder download <ids>` | Download paper PDFs |
+| `quantcoder summarize <id>` | Create strategy summary from paper |
+| `quantcoder summaries` | List all summaries |
+| `quantcoder generate <id>` | Generate QuantConnect code |
+| `quantcoder validate <file>` | Validate generated code |
+| `quantcoder backtest <file>` | Run backtest on QuantConnect |
+
+### Schedule Commands
+
+| Command | Description |
+|---------|-------------|
+| `quantcoder schedule start` | Start scheduled pipeline |
+| `quantcoder schedule run` | Run pipeline once |
+| `quantcoder schedule status` | Show scheduler status |
+| `quantcoder schedule config` | Configure integrations |
+
+### Evolution Commands
+
+| Command | Description |
+|---------|-------------|
+| `quantcoder evolve start <file>` | Start evolution from code file |
+| `quantcoder evolve list` | List saved evolutions |
+| `quantcoder evolve show <id>` | Show evolution details |
+| `quantcoder evolve export <id>` | Export best variant |
+
+### Autonomous Mode Commands
+
+| Command | Description |
+|---------|-------------|
+| `quantcoder auto start` | Start autonomous mode |
+| `quantcoder auto status` | Show learning statistics |
+| `quantcoder auto report` | Generate learning report |
+
+### Logging Commands
+
+| Command | Description |
+|---------|-------------|
+| `quantcoder logs show` | Show recent log entries |
+| `quantcoder logs list` | List all log files |
+| `quantcoder logs clear` | Clear old log files |
+| `quantcoder logs config` | Configure logging settings |
+
+---
+
+## Configuration
+
+Configuration is stored in `~/.quantcoder/config.toml`:
+
+```toml
+[model]
+provider = "anthropic"  # anthropic, openai, mistral, deepseek, ollama
+model = "claude-sonnet-4-5-20250929"
+temperature = 0.5
+max_tokens = 3000
+
+[ui]
+theme = "monokai"
+auto_approve = false
+show_token_usage = true
+editor = "zed"  # zed, code, vim, etc.
+
+[tools]
+enabled_tools = ["*"]
+disabled_tools = []
+downloads_dir = "downloads"
+generated_code_dir = "generated_code"
+
+[logging]
+level = "INFO"           # DEBUG, INFO, WARNING, ERROR
+format = "standard"      # standard, json
+max_file_size_mb = 10
+backup_count = 5
+alert_on_error = false
+webhook_url = ""         # For Slack/Discord alerts
+```
+
+---
+
+## Logging & Monitoring
+
+### Log Files
+
+Logs are stored in `~/.quantcoder/logs/`:
+
+| File | Format | Purpose |
+|------|--------|---------|
+| `quantcoder.log` | Human-readable | Console-style logs |
+| `quantcoder.json.log` | JSON | Structured logs for parsing |
+| `quantcoder.log.1` | Rotated | Backup files |
+
+### View Logs
+
+```bash
+# Show recent entries
+quantcoder logs show
+
+# Show more entries
+quantcoder logs show --lines 100
+
+# Show JSON structured logs
+quantcoder logs show --json
+
+# List all log files
+quantcoder logs list
+```
+
+### Configure Logging
+
+```bash
+# Show current config
+quantcoder logs config --show
+
+# Set log level
+quantcoder logs config --level DEBUG
+
+# Configure rotation
+quantcoder logs config --max-size 20 --backups 10
+
+# Enable webhook alerts
+quantcoder logs config --webhook https://hooks.slack.com/services/xxx
+```
+
+### Webhook Alerts
+
+Set `QUANTCODER_WEBHOOK_URL` or use `--webhook` to receive alerts on ERROR/CRITICAL events.
+
+Payload format:
+```json
+{
+  "timestamp": "2026-01-28T10:30:00Z",
+  "level": "ERROR",
+  "logger": "quantcoder.scheduler.runner",
+  "message": "Pipeline failed",
+  "module": "runner",
+  "function": "run_pipeline"
+}
+```
+
+### AutoStats Persistence
+
+Autonomous mode statistics are persisted to `~/.quantcoder/stats/`:
+
+```bash
+# View stats
+quantcoder auto status
+
+# Generate report
+quantcoder auto report --format json
+```
+
+---
+
+## Deep Search with Tavily
+
+Traditional keyword search (CrossRef) may miss relevant papers. Deep search uses Tavily's semantic search + LLM filtering.
+
+### Setup
+
+```bash
+# Get API key from https://tavily.com
+quantcoder schedule config --tavily-key tvly-xxx
+```
+
+### Usage
+
+```bash
+# Semantic deep search
+quantcoder search "pairs trading with cointegration" --deep
+
+# With more results
+quantcoder search "factor investing" --deep --num 10
+
+# Skip LLM filtering (faster, more results)
+quantcoder search "momentum" --deep --no-filter
+```
+
+### How It Works
+
+```
+Query → Tavily Semantic Search → Academic Filters (arxiv, ssrn, etc.)
+      → LLM Relevance Check → Implementable Strategies Only
+```
+
+The LLM filter removes papers that:
+- Are purely theoretical with no trading application
+- Lack actionable entry/exit signals
+- Are surveys or meta-analyses without novel strategies
+
+---
+
+## Strategy Evolution
+
+AlphaEvolve-inspired optimization that uses LLM-generated mutations instead of parameter grid search.
+
+### Start Evolution
+
+```bash
+# From generated code
+quantcoder evolve start ./generated_code/strategy_1.py
+
+# With options
+quantcoder evolve start strategy.py \
+  --generations 10 \
+  --variants 5 \
+  --start-date 2019-01-01 \
+  --end-date 2024-01-01
+```
+
+### Or Integrate with Generate
+
+```bash
+# Generate → Backtest → Evolve → Publish
+quantcoder generate 1 --backtest --evolve --gens 5 --variants 3
+```
+
+### Evolution Process
+
+1. **Initial Population**: Start with base strategy
+2. **Variation**: LLM generates N variants per generation
+3. **Evaluation**: Backtest each variant on QuantConnect
+4. **Selection**: Keep elite performers
+5. **Mutation**: Apply targeted improvements
+6. **Repeat**: Until convergence or max generations
+
+### Manage Evolutions
+
+```bash
+# List all evolutions
+quantcoder evolve list
+
+# Show details
+quantcoder evolve show evo_20260128_123456
+
+# Export best variant
+quantcoder evolve export evo_20260128_123456 --output best_strategy.py
+```
+
+---
+
+## Notion Integration
+
+Publish successful strategies as formatted articles in your Notion database.
+
+### Setup
+
+1. Create a Notion integration at https://www.notion.so/my-integrations
+2. Share your database with the integration
+3. Configure QuantCoder:
+
+```bash
+quantcoder schedule config \
+  --notion-key secret_xxx \
+  --notion-db your_database_id
+```
+
+### Automatic Publishing
+
+Strategies are published when:
+- Backtest Sharpe ratio >= `min_sharpe` (default: 0.5)
+- Using `--backtest` flag with `generate` command
+- Or running scheduled pipeline
+
+### Article Format
+
+Published articles include:
+
+| Section | Content |
+|---------|---------|
+| Title | Performance-based title (e.g., "High-Performance Momentum Strategy") |
+| Paper Reference | Original paper title, URL, authors |
+| Strategy Summary | Extracted strategy description |
+| Backtest Results | Sharpe, returns, drawdown, win rate |
+| Code Snippet | First 2000 chars of generated code |
+| Tags | Strategy type (momentum, mean_reversion, etc.) |
+
+---
+
+## Environment Variables
+
+### Required
+
+| Variable | Description |
+|----------|-------------|
+| `ANTHROPIC_API_KEY` | Anthropic API key (for Claude models) |
+| `OPENAI_API_KEY` | OpenAI API key (alternative) |
+
+### QuantConnect
+
+| Variable | Description |
+|----------|-------------|
+| `QUANTCONNECT_API_KEY` | QuantConnect API key |
+| `QUANTCONNECT_USER_ID` | QuantConnect user ID |
+| `QC_PROJECT_ID` | Default project ID (optional) |
+
+### Integrations
+
+| Variable | Description |
+|----------|-------------|
+| `NOTION_API_KEY` | Notion integration secret |
+| `NOTION_DATABASE_ID` | Target database ID |
+| `TAVILY_API_KEY` | Tavily API key for deep search |
+
+### Monitoring
+
+| Variable | Description |
+|----------|-------------|
+| `QUANTCODER_WEBHOOK_URL` | Webhook URL for error alerts |
+
+---
+
+## Example Full Workflow
+
+### Manual Workflow
+
+```bash
+# 1. Search for papers
+quantcoder search "statistical arbitrage" --deep --num 5
+
+# 2. Download promising papers
+quantcoder download 1 2
+
+# 3. Create summaries
+quantcoder summarize 1
+quantcoder summarize 2
+
+# 4. List summaries
+quantcoder summaries
+
+# 5. Generate, backtest, evolve, and publish
+quantcoder generate 1 \
+  --backtest \
+  --min-sharpe 1.0 \
+  --evolve \
+  --gens 5 \
+  --open-in-editor
+```
+
+### Automated Workflow
+
+```bash
+# Configure once
+quantcoder schedule config \
+  --notion-key secret_xxx \
+  --notion-db xxx \
+  --tavily-key tvly-xxx
+
+# Start daily automation
+quantcoder schedule start \
+  --interval daily \
+  --hour 6 \
+  --queries "momentum,mean reversion,factor investing" \
+  --min-sharpe 1.0 \
+  --evolve \
+  --gens 5 \
+  --run-now
+
+# Monitor
+quantcoder schedule status
+quantcoder logs show --lines 50
+```
+
+---
+
+## Troubleshooting
+
+### Common Issues
+
+| Issue | Solution |
+|-------|----------|
+| "API key not found" | Check `~/.quantcoder/.env` |
+| "QuantConnect credentials not configured" | Set `QUANTCONNECT_API_KEY` and `QUANTCONNECT_USER_ID` |
+| "Tavily API key not set" | Run `quantcoder schedule config --tavily-key xxx` |
+| "Notion credentials not configured" | Run `quantcoder schedule config --notion-key xxx --notion-db xxx` |
+| Backtest timeout | Increase timeout or simplify strategy |
+| Evolution not improving | Try more generations or higher mutation rate |
+
+### Debug Mode
+
+```bash
+# Enable verbose logging
+quantcoder --verbose search "test"
+
+# Set debug level permanently
+quantcoder logs config --level DEBUG
+```
+
+### Check Logs
+
+```bash
+# View recent errors
+quantcoder logs show --lines 100 | grep -i error
+
+# View JSON logs for analysis
+quantcoder logs show --json
+```
+
+---
+
+## Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        QuantCoder CLI                           │
+├─────────────────────────────────────────────────────────────────┤
+│  Workflows                                                      │
+│  ├── Spot Generation (manual)                                  │
+│  └── Batch Mode (automated)                                    │
+├─────────────────────────────────────────────────────────────────┤
+│  Core Components                                                │
+│  ├── Paper Search (CrossRef, Tavily)                           │
+│  ├── PDF Processing & Summarization                            │
+│  ├── Code Generation (multi-provider LLM)                      │
+│  ├── Validation & Auto-refinement                              │
+│  ├── QuantConnect Integration                                  │
+│  └── Evolution Engine                                          │
+├─────────────────────────────────────────────────────────────────┤
+│  Integrations                                                   │
+│  ├── Notion (article publishing)                               │
+│  ├── Tavily (semantic search)                                  │
+│  └── Webhooks (alerting)                                       │
+├─────────────────────────────────────────────────────────────────┤
+│  Monitoring                                                     │
+│  ├── Structured Logging (JSON + standard)                      │
+│  ├── Log Rotation                                              │
+│  ├── AutoStats Persistence                                     │
+│  └── Webhook Alerts                                            │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+*Last updated: January 2026*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "prompt-toolkit>=3.0.43",
     "toml>=0.10.2",
     "InquirerPy>=0.3.4",
+    "apscheduler>=3.10.0",
 ]
 
 [project.optional-dependencies]

--- a/quantcoder/cli.py
+++ b/quantcoder/cli.py
@@ -957,9 +957,9 @@ def schedule():
 @click.option('--hour', default=6, type=int, help='Hour to run (for daily/weekly)')
 @click.option('--day', default='mon', help='Day of week (for weekly)')
 @click.option('--queries', help='Comma-separated search queries')
-@click.option('--min-sharpe', default=0.5, type=float, help='Minimum Sharpe ratio')
-@click.option('--max-strategies', default=3, type=int, help='Max strategies per run')
-@click.option('--notion-min-sharpe', default=0.8, type=float, help='Min Sharpe for Notion publishing')
+@click.option('--min-sharpe', default=0.5, type=float, help='Acceptance criteria - min Sharpe to keep algo')
+@click.option('--max-strategies', default=10, type=int, help='Batch limit - max strategies per run')
+@click.option('--notion-min-sharpe', default=0.5, type=float, help='Min Sharpe for Notion article (defaults to min-sharpe)')
 @click.option('--output', type=click.Path(), help='Output directory')
 @click.option('--run-now', is_flag=True, help='Run immediately before starting schedule')
 @click.pass_context
@@ -1046,8 +1046,8 @@ def schedule_start(ctx, interval, hour, day, queries, min_sharpe, max_strategies
 
 @schedule.command(name='run')
 @click.option('--queries', help='Comma-separated search queries')
-@click.option('--min-sharpe', default=0.5, type=float, help='Minimum Sharpe ratio')
-@click.option('--max-strategies', default=3, type=int, help='Max strategies per run')
+@click.option('--min-sharpe', default=0.5, type=float, help='Acceptance criteria - min Sharpe to keep algo')
+@click.option('--max-strategies', default=10, type=int, help='Batch limit - max strategies per run')
 @click.option('--output', type=click.Path(), help='Output directory')
 @click.pass_context
 def schedule_run(ctx, queries, min_sharpe, max_strategies, output):

--- a/quantcoder/config.py
+++ b/quantcoder/config.py
@@ -65,10 +65,10 @@ class SchedulerConfig:
     hour: int = 6
     minute: int = 0
     day_of_week: str = "mon"
-    min_sharpe_ratio: float = 0.5
-    max_strategies_per_run: int = 3
-    publish_to_notion: bool = True
-    notion_min_sharpe: float = 0.8
+    min_sharpe_ratio: float = 0.5  # Acceptance criteria - algo kept in QC if passes
+    max_strategies_per_run: int = 10  # Batch limit per scheduled run
+    publish_to_notion: bool = True  # Push article for successful algos
+    notion_min_sharpe: float = 0.5  # Same as acceptance criteria
 
 
 @dataclass

--- a/quantcoder/config.py
+++ b/quantcoder/config.py
@@ -216,6 +216,26 @@ class Config:
         user_id = os.getenv("QUANTCONNECT_USER_ID")
         return bool(api_key and user_id)
 
+    def has_tavily_api_key(self) -> bool:
+        """Check if Tavily API key is available for deep search."""
+        from dotenv import load_dotenv
+
+        env_path = self.home_dir / ".env"
+        if env_path.exists():
+            load_dotenv(env_path)
+
+        return bool(os.getenv("TAVILY_API_KEY"))
+
+    def get_tavily_api_key(self) -> Optional[str]:
+        """Get Tavily API key from environment."""
+        from dotenv import load_dotenv
+
+        env_path = self.home_dir / ".env"
+        if env_path.exists():
+            load_dotenv(env_path)
+
+        return os.getenv("TAVILY_API_KEY")
+
     def save_api_key(self, api_key: str):
         """Save API key to .env file."""
         env_path = self.home_dir / ".env"

--- a/quantcoder/config.py
+++ b/quantcoder/config.py
@@ -58,6 +58,27 @@ class MultiAgentConfig:
 
 
 @dataclass
+class SchedulerConfig:
+    """Configuration for automated scheduling."""
+    enabled: bool = True
+    interval: str = "daily"  # hourly, daily, weekly
+    hour: int = 6
+    minute: int = 0
+    day_of_week: str = "mon"
+    min_sharpe_ratio: float = 0.5
+    max_strategies_per_run: int = 3
+    publish_to_notion: bool = True
+    notion_min_sharpe: float = 0.8
+
+
+@dataclass
+class NotionConfig:
+    """Configuration for Notion integration."""
+    api_key: Optional[str] = None
+    database_id: Optional[str] = None
+
+
+@dataclass
 class Config:
     """Main configuration class for QuantCoder."""
 
@@ -65,6 +86,8 @@ class Config:
     ui: UIConfig = field(default_factory=UIConfig)
     tools: ToolsConfig = field(default_factory=ToolsConfig)
     multi_agent: MultiAgentConfig = field(default_factory=MultiAgentConfig)
+    scheduler: SchedulerConfig = field(default_factory=SchedulerConfig)
+    notion: NotionConfig = field(default_factory=NotionConfig)
     api_key: Optional[str] = None
     quantconnect_api_key: Optional[str] = None
     quantconnect_user_id: Optional[str] = None

--- a/quantcoder/config.py
+++ b/quantcoder/config.py
@@ -3,11 +3,24 @@
 import os
 import toml
 from pathlib import Path
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, List
 from dataclasses import dataclass, field
 import logging
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class LoggingConfigSettings:
+    """Configuration for logging system."""
+    level: str = "INFO"  # DEBUG, INFO, WARNING, ERROR
+    format: str = "standard"  # standard, json
+    max_file_size_mb: int = 10
+    backup_count: int = 5
+    rotate_when: str = "midnight"  # midnight, h (hourly), d (daily)
+    alert_on_error: bool = False
+    webhook_url: Optional[str] = None
+    alert_levels: List[str] = field(default_factory=lambda: ["ERROR", "CRITICAL"])
 
 
 @dataclass
@@ -88,6 +101,7 @@ class Config:
     multi_agent: MultiAgentConfig = field(default_factory=MultiAgentConfig)
     scheduler: SchedulerConfig = field(default_factory=SchedulerConfig)
     notion: NotionConfig = field(default_factory=NotionConfig)
+    logging: LoggingConfigSettings = field(default_factory=LoggingConfigSettings)
     api_key: Optional[str] = None
     quantconnect_api_key: Optional[str] = None
     quantconnect_user_id: Optional[str] = None
@@ -124,6 +138,8 @@ class Config:
             config.ui = UIConfig(**data["ui"])
         if "tools" in data:
             config.tools = ToolsConfig(**data["tools"])
+        if "logging" in data:
+            config.logging = LoggingConfigSettings(**data["logging"])
 
         return config
 
@@ -149,6 +165,16 @@ class Config:
                 "disabled_tools": self.tools.disabled_tools,
                 "downloads_dir": self.tools.downloads_dir,
                 "generated_code_dir": self.tools.generated_code_dir,
+            },
+            "logging": {
+                "level": self.logging.level,
+                "format": self.logging.format,
+                "max_file_size_mb": self.logging.max_file_size_mb,
+                "backup_count": self.logging.backup_count,
+                "rotate_when": self.logging.rotate_when,
+                "alert_on_error": self.logging.alert_on_error,
+                "webhook_url": self.logging.webhook_url,
+                "alert_levels": self.logging.alert_levels,
             }
         }
 
@@ -246,3 +272,27 @@ class Config:
 
         logger.info(f"API key saved to {env_path}")
         self.api_key = api_key
+
+    def get_logging_config(self):
+        """Get logging configuration for setup_logging()."""
+        from quantcoder.logging_config import LoggingConfig
+
+        # Check for webhook URL in environment
+        from dotenv import load_dotenv
+        env_path = self.home_dir / ".env"
+        if env_path.exists():
+            load_dotenv(env_path)
+
+        webhook_url = self.logging.webhook_url or os.getenv("QUANTCODER_WEBHOOK_URL")
+
+        return LoggingConfig(
+            level=self.logging.level,
+            format=self.logging.format,
+            log_dir=self.home_dir / "logs",
+            max_file_size_mb=self.logging.max_file_size_mb,
+            backup_count=self.logging.backup_count,
+            rotate_when=self.logging.rotate_when,
+            alert_on_error=self.logging.alert_on_error,
+            webhook_url=webhook_url,
+            alert_levels=self.logging.alert_levels,
+        )

--- a/quantcoder/core/__init__.py
+++ b/quantcoder/core/__init__.py
@@ -1,6 +1,17 @@
 """Core modules for QuantCoder."""
 
-from .processor import ArticleProcessor
-from .llm import LLMHandler
+# Lazy imports to avoid loading heavy dependencies at import time
+__all__ = ["ArticleProcessor", "LLMHandler", "SummaryStore"]
 
-__all__ = ["ArticleProcessor", "LLMHandler"]
+
+def __getattr__(name):
+    if name == "ArticleProcessor":
+        from .processor import ArticleProcessor
+        return ArticleProcessor
+    if name == "LLMHandler":
+        from .llm import LLMHandler
+        return LLMHandler
+    if name == "SummaryStore":
+        from .summary_store import SummaryStore
+        return SummaryStore
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/quantcoder/core/summary_store.py
+++ b/quantcoder/core/summary_store.py
@@ -1,0 +1,244 @@
+"""Storage and management for article summaries."""
+
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional
+from dataclasses import dataclass, field, asdict
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class IndividualSummary:
+    """Summary of a single article."""
+    article_id: int
+    title: str
+    authors: str
+    url: str
+    strategy_type: str
+    key_concepts: List[str]
+    indicators: List[str]
+    risk_approach: str
+    summary_text: str
+    created_at: str = field(default_factory=lambda: datetime.now().isoformat())
+
+    def to_dict(self) -> Dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict) -> "IndividualSummary":
+        return cls(**data)
+
+
+@dataclass
+class ConsolidatedSummary:
+    """Consolidated summary from multiple articles."""
+    summary_id: int
+    source_article_ids: List[int]
+    references: List[Dict]  # [{id, title, contribution}, ...]
+    merged_strategy_type: str
+    merged_description: str
+    contributions_by_article: Dict[int, str]  # {article_id: "what it contributes"}
+    key_concepts: List[str]
+    indicators: List[str]
+    risk_approach: str
+    created_at: str = field(default_factory=lambda: datetime.now().isoformat())
+    is_consolidated: bool = True
+
+    def to_dict(self) -> Dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict) -> "ConsolidatedSummary":
+        return cls(**data)
+
+
+class SummaryStore:
+    """Manages storage and retrieval of article summaries."""
+
+    def __init__(self, base_dir: Path):
+        """Initialize summary store.
+
+        Args:
+            base_dir: Base directory for storage (e.g., ~/.quantcoder)
+        """
+        self.base_dir = Path(base_dir)
+        self.summaries_dir = self.base_dir / "summaries"
+        self.summaries_dir.mkdir(parents=True, exist_ok=True)
+
+        self.index_file = self.summaries_dir / "index.json"
+        self._load_index()
+
+    def _load_index(self):
+        """Load the summary index."""
+        if self.index_file.exists():
+            with open(self.index_file, 'r') as f:
+                self.index = json.load(f)
+        else:
+            self.index = {
+                "individual": {},  # article_id -> summary_id
+                "consolidated": {},  # summary_id -> {source_ids, ...}
+                "next_id": 1
+            }
+            self._save_index()
+
+    def _save_index(self):
+        """Save the summary index."""
+        with open(self.index_file, 'w') as f:
+            json.dump(self.index, f, indent=2)
+
+    def _get_next_id(self) -> int:
+        """Get next available summary ID."""
+        next_id = self.index["next_id"]
+        self.index["next_id"] = next_id + 1
+        self._save_index()
+        return next_id
+
+    def save_individual(self, summary: IndividualSummary) -> int:
+        """Save an individual article summary.
+
+        Args:
+            summary: The individual summary to save
+
+        Returns:
+            The summary ID
+        """
+        # Check if already exists
+        article_id_str = str(summary.article_id)
+        if article_id_str in self.index["individual"]:
+            summary_id = self.index["individual"][article_id_str]
+        else:
+            summary_id = self._get_next_id()
+            self.index["individual"][article_id_str] = summary_id
+            self._save_index()
+
+        # Save summary file
+        summary_file = self.summaries_dir / f"summary_{summary_id}.json"
+        data = summary.to_dict()
+        data["summary_id"] = summary_id
+        data["is_consolidated"] = False
+
+        with open(summary_file, 'w') as f:
+            json.dump(data, f, indent=2)
+
+        logger.info(f"Saved individual summary {summary_id} for article {summary.article_id}")
+        return summary_id
+
+    def save_consolidated(self, summary: ConsolidatedSummary) -> int:
+        """Save a consolidated summary.
+
+        Args:
+            summary: The consolidated summary to save
+
+        Returns:
+            The summary ID
+        """
+        summary_id = self._get_next_id()
+        summary.summary_id = summary_id
+
+        # Update index
+        self.index["consolidated"][str(summary_id)] = {
+            "source_ids": summary.source_article_ids,
+            "created_at": summary.created_at
+        }
+        self._save_index()
+
+        # Save summary file
+        summary_file = self.summaries_dir / f"summary_{summary_id}.json"
+        with open(summary_file, 'w') as f:
+            json.dump(summary.to_dict(), f, indent=2)
+
+        logger.info(f"Saved consolidated summary {summary_id} from articles {summary.source_article_ids}")
+        return summary_id
+
+    def get_summary(self, summary_id: int) -> Optional[Dict]:
+        """Get a summary by ID.
+
+        Args:
+            summary_id: The summary ID
+
+        Returns:
+            Summary data dict or None
+        """
+        summary_file = self.summaries_dir / f"summary_{summary_id}.json"
+        if summary_file.exists():
+            with open(summary_file, 'r') as f:
+                return json.load(f)
+        return None
+
+    def get_summary_id_for_article(self, article_id: int) -> Optional[int]:
+        """Get summary ID for an article.
+
+        Args:
+            article_id: The article ID
+
+        Returns:
+            Summary ID or None
+        """
+        return self.index["individual"].get(str(article_id))
+
+    def is_consolidated(self, summary_id: int) -> bool:
+        """Check if a summary ID is consolidated.
+
+        Args:
+            summary_id: The summary ID
+
+        Returns:
+            True if consolidated
+        """
+        return str(summary_id) in self.index["consolidated"]
+
+    def list_summaries(self) -> Dict:
+        """List all summaries.
+
+        Returns:
+            Dict with individual and consolidated summaries
+        """
+        result = {
+            "individual": [],
+            "consolidated": []
+        }
+
+        # Individual summaries
+        for article_id, summary_id in self.index["individual"].items():
+            summary = self.get_summary(summary_id)
+            if summary:
+                result["individual"].append({
+                    "summary_id": summary_id,
+                    "article_id": int(article_id),
+                    "title": summary.get("title", "Unknown"),
+                    "strategy_type": summary.get("strategy_type", "Unknown")
+                })
+
+        # Consolidated summaries
+        for summary_id, info in self.index["consolidated"].items():
+            summary = self.get_summary(int(summary_id))
+            if summary:
+                result["consolidated"].append({
+                    "summary_id": int(summary_id),
+                    "source_article_ids": info["source_ids"],
+                    "strategy_type": summary.get("merged_strategy_type", "hybrid"),
+                    "created_at": info.get("created_at")
+                })
+
+        return result
+
+    def get_individual_summaries(self, article_ids: List[int]) -> List[Dict]:
+        """Get multiple individual summaries.
+
+        Args:
+            article_ids: List of article IDs
+
+        Returns:
+            List of summary dicts
+        """
+        summaries = []
+        for article_id in article_ids:
+            summary_id = self.get_summary_id_for_article(article_id)
+            if summary_id:
+                summary = self.get_summary(summary_id)
+                if summary:
+                    summaries.append(summary)
+        return summaries

--- a/quantcoder/logging_config.py
+++ b/quantcoder/logging_config.py
@@ -1,0 +1,337 @@
+"""
+Centralized Logging Configuration for QuantCoder
+=================================================
+
+Provides configurable logging with:
+- Log rotation (size-based and time-based)
+- Structured JSON logging option
+- Per-module log level control
+- Webhook alerting for failures
+"""
+
+import logging
+import json
+import os
+from datetime import datetime
+from logging.handlers import RotatingFileHandler, TimedRotatingFileHandler
+from pathlib import Path
+from typing import Optional, Dict, Any, Callable, List
+from dataclasses import dataclass, field
+import threading
+
+
+@dataclass
+class LoggingConfig:
+    """Configuration for logging system."""
+    level: str = "INFO"
+    format: str = "standard"  # standard, json
+    log_dir: Optional[Path] = None
+
+    # File rotation settings
+    max_file_size_mb: int = 10
+    backup_count: int = 5
+    rotate_when: str = "midnight"  # midnight, h (hourly), d (daily)
+
+    # Per-module levels (module_name -> level)
+    module_levels: Dict[str, str] = field(default_factory=dict)
+
+    # Alerting
+    alert_on_error: bool = False
+    webhook_url: Optional[str] = None
+    alert_levels: List[str] = field(default_factory=lambda: ["ERROR", "CRITICAL"])
+
+
+class JSONFormatter(logging.Formatter):
+    """JSON formatter for structured logging."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        log_data = {
+            "timestamp": datetime.utcnow().isoformat() + "Z",
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+            "module": record.module,
+            "function": record.funcName,
+            "line": record.lineno,
+        }
+
+        # Add exception info if present
+        if record.exc_info:
+            log_data["exception"] = self.formatException(record.exc_info)
+
+        # Add extra fields if present
+        if hasattr(record, "extra_data"):
+            log_data["extra"] = record.extra_data
+
+        return json.dumps(log_data)
+
+
+class WebhookHandler(logging.Handler):
+    """Handler that sends alerts to a webhook URL."""
+
+    def __init__(self, webhook_url: str, alert_levels: List[str] = None):
+        super().__init__()
+        self.webhook_url = webhook_url
+        self.alert_levels = alert_levels or ["ERROR", "CRITICAL"]
+        self._lock = threading.Lock()
+
+    def emit(self, record: logging.LogRecord):
+        if record.levelname not in self.alert_levels:
+            return
+
+        try:
+            import requests
+
+            payload = {
+                "timestamp": datetime.utcnow().isoformat() + "Z",
+                "level": record.levelname,
+                "logger": record.name,
+                "message": record.getMessage(),
+                "module": record.module,
+                "function": record.funcName,
+            }
+
+            if record.exc_info:
+                payload["exception"] = self.format(record)
+
+            with self._lock:
+                requests.post(
+                    self.webhook_url,
+                    json=payload,
+                    timeout=5,
+                    headers={"Content-Type": "application/json"}
+                )
+        except Exception:
+            # Don't let webhook failures break logging
+            pass
+
+
+class QuantCoderLogger:
+    """
+    Central logging manager for QuantCoder.
+
+    Usage:
+        from quantcoder.logging_config import setup_logging, get_logger
+
+        # Setup once at startup
+        setup_logging(verbose=True)
+
+        # Get logger in any module
+        logger = get_logger(__name__)
+        logger.info("Starting process")
+    """
+
+    _instance = None
+    _initialized = False
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __init__(self):
+        if QuantCoderLogger._initialized:
+            return
+        self.config: Optional[LoggingConfig] = None
+        self.handlers: List[logging.Handler] = []
+        QuantCoderLogger._initialized = True
+
+    def setup(
+        self,
+        verbose: bool = False,
+        config: Optional[LoggingConfig] = None,
+        console_handler: Optional[logging.Handler] = None,
+    ):
+        """
+        Initialize logging system.
+
+        Args:
+            verbose: Enable DEBUG level logging
+            config: Optional LoggingConfig for advanced settings
+            console_handler: Optional custom console handler (e.g., RichHandler)
+        """
+        # Clean up existing handlers
+        self.cleanup()
+
+        # Use provided config or defaults
+        self.config = config or LoggingConfig()
+
+        # Determine log level
+        if verbose:
+            level = logging.DEBUG
+        else:
+            level = getattr(logging, self.config.level.upper(), logging.INFO)
+
+        # Get log directory
+        log_dir = self.config.log_dir or Path.home() / ".quantcoder" / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+
+        # Create root logger
+        root_logger = logging.getLogger("quantcoder")
+        root_logger.setLevel(level)
+
+        # Choose formatter
+        if self.config.format == "json":
+            formatter = JSONFormatter()
+        else:
+            formatter = logging.Formatter(
+                "%(asctime)s | %(levelname)-8s | %(name)s | %(message)s",
+                datefmt="%Y-%m-%d %H:%M:%S"
+            )
+
+        # Console handler
+        if console_handler:
+            console_handler.setLevel(level)
+            if not hasattr(console_handler, '_custom_formatter'):
+                console_handler.setFormatter(formatter)
+            root_logger.addHandler(console_handler)
+            self.handlers.append(console_handler)
+        else:
+            console = logging.StreamHandler()
+            console.setLevel(level)
+            console.setFormatter(formatter)
+            root_logger.addHandler(console)
+            self.handlers.append(console)
+
+        # Rotating file handler (size-based)
+        log_file = log_dir / "quantcoder.log"
+        file_handler = RotatingFileHandler(
+            log_file,
+            maxBytes=self.config.max_file_size_mb * 1024 * 1024,
+            backupCount=self.config.backup_count,
+        )
+        file_handler.setLevel(level)
+        file_handler.setFormatter(formatter)
+        root_logger.addHandler(file_handler)
+        self.handlers.append(file_handler)
+
+        # JSON log file (always structured for parsing)
+        json_log_file = log_dir / "quantcoder.json.log"
+        json_handler = RotatingFileHandler(
+            json_log_file,
+            maxBytes=self.config.max_file_size_mb * 1024 * 1024,
+            backupCount=self.config.backup_count,
+        )
+        json_handler.setLevel(level)
+        json_handler.setFormatter(JSONFormatter())
+        root_logger.addHandler(json_handler)
+        self.handlers.append(json_handler)
+
+        # Webhook handler for alerts
+        if self.config.alert_on_error and self.config.webhook_url:
+            webhook_handler = WebhookHandler(
+                self.config.webhook_url,
+                self.config.alert_levels
+            )
+            webhook_handler.setLevel(logging.ERROR)
+            root_logger.addHandler(webhook_handler)
+            self.handlers.append(webhook_handler)
+
+        # Apply per-module log levels
+        for module_name, module_level in self.config.module_levels.items():
+            module_logger = logging.getLogger(module_name)
+            module_logger.setLevel(getattr(logging, module_level.upper(), logging.INFO))
+
+        # Reduce noise from third-party libraries
+        logging.getLogger("urllib3").setLevel(logging.WARNING)
+        logging.getLogger("requests").setLevel(logging.WARNING)
+        logging.getLogger("httpx").setLevel(logging.WARNING)
+        logging.getLogger("apscheduler").setLevel(logging.WARNING)
+
+        root_logger.info(f"Logging initialized: level={logging.getLevelName(level)}, dir={log_dir}")
+
+    def cleanup(self):
+        """Remove all handlers from root logger."""
+        root_logger = logging.getLogger("quantcoder")
+        for handler in self.handlers:
+            try:
+                handler.close()
+                root_logger.removeHandler(handler)
+            except Exception:
+                pass
+        self.handlers.clear()
+
+    def get_log_files(self) -> List[Path]:
+        """Get list of all log files."""
+        if not self.config or not self.config.log_dir:
+            log_dir = Path.home() / ".quantcoder" / "logs"
+        else:
+            log_dir = self.config.log_dir
+
+        if not log_dir.exists():
+            return []
+
+        return sorted(log_dir.glob("quantcoder*.log*"))
+
+
+# Module-level functions for convenience
+_logger_manager = QuantCoderLogger()
+
+
+def setup_logging(
+    verbose: bool = False,
+    config: Optional[LoggingConfig] = None,
+    console_handler: Optional[logging.Handler] = None,
+):
+    """
+    Setup logging for QuantCoder.
+
+    Call this once at application startup.
+
+    Args:
+        verbose: Enable DEBUG level
+        config: Optional LoggingConfig for advanced settings
+        console_handler: Optional custom console handler
+    """
+    _logger_manager.setup(verbose, config, console_handler)
+
+
+def get_logger(name: str) -> logging.Logger:
+    """
+    Get a logger for a module.
+
+    Args:
+        name: Module name (typically __name__)
+
+    Returns:
+        Logger instance
+    """
+    # Ensure it's under quantcoder namespace
+    if not name.startswith("quantcoder"):
+        name = f"quantcoder.{name}"
+    return logging.getLogger(name)
+
+
+def get_log_files() -> List[Path]:
+    """Get list of all log files."""
+    return _logger_manager.get_log_files()
+
+
+def log_with_context(
+    logger: logging.Logger,
+    level: int,
+    message: str,
+    **context
+):
+    """
+    Log a message with additional context data.
+
+    The context will appear in structured (JSON) logs.
+
+    Args:
+        logger: Logger instance
+        level: Log level (logging.INFO, etc.)
+        message: Log message
+        **context: Additional context key-value pairs
+    """
+    record = logger.makeRecord(
+        logger.name,
+        level,
+        "",
+        0,
+        message,
+        (),
+        None,
+    )
+    record.extra_data = context
+    logger.handle(record)

--- a/quantcoder/scheduler/__init__.py
+++ b/quantcoder/scheduler/__init__.py
@@ -1,0 +1,19 @@
+"""Automated scheduler module for QuantCoder.
+
+This module provides:
+- Scheduled strategy discovery and backtesting
+- Notion integration for publishing strategy articles
+- Automated end-to-end workflow orchestration
+"""
+
+from .notion_client import NotionClient
+from .article_generator import ArticleGenerator
+from .runner import ScheduledRunner
+from .automated_pipeline import AutomatedBacktestPipeline
+
+__all__ = [
+    "NotionClient",
+    "ArticleGenerator",
+    "ScheduledRunner",
+    "AutomatedBacktestPipeline",
+]

--- a/quantcoder/scheduler/__init__.py
+++ b/quantcoder/scheduler/__init__.py
@@ -6,14 +6,19 @@ This module provides:
 - Automated end-to-end workflow orchestration
 """
 
-from .notion_client import NotionClient
-from .article_generator import ArticleGenerator
-from .runner import ScheduledRunner
-from .automated_pipeline import AutomatedBacktestPipeline
+from .notion_client import NotionClient, StrategyArticle
+from .article_generator import ArticleGenerator, StrategyReport
+from .runner import ScheduledRunner, ScheduleConfig, ScheduleInterval
+from .automated_pipeline import AutomatedBacktestPipeline, PipelineConfig
 
 __all__ = [
     "NotionClient",
+    "StrategyArticle",
     "ArticleGenerator",
+    "StrategyReport",
     "ScheduledRunner",
+    "ScheduleConfig",
+    "ScheduleInterval",
     "AutomatedBacktestPipeline",
+    "PipelineConfig",
 ]

--- a/quantcoder/scheduler/article_generator.py
+++ b/quantcoder/scheduler/article_generator.py
@@ -1,0 +1,326 @@
+"""Article generator for strategy reports."""
+
+import json
+import logging
+from typing import Optional, Dict, Any, List
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+from .notion_client import StrategyArticle
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class StrategyReport:
+    """Complete strategy report with all metadata."""
+    strategy_name: str
+    paper_title: str
+    paper_url: str
+    paper_authors: List[str]
+    paper_abstract: str
+    strategy_type: str
+    strategy_summary: str
+    code_files: Dict[str, str]
+    backtest_results: Dict[str, Any]
+    quantconnect_project_id: Optional[str] = None
+    quantconnect_backtest_id: Optional[str] = None
+    generated_at: Optional[datetime] = None
+
+    def __post_init__(self):
+        if self.generated_at is None:
+            self.generated_at = datetime.now()
+
+
+class ArticleGenerator:
+    """Generates formatted articles from strategy reports."""
+
+    def __init__(self, llm_provider=None):
+        """Initialize article generator.
+
+        Args:
+            llm_provider: Optional LLM provider for enhanced summaries
+        """
+        self.llm = llm_provider
+
+    def generate_title(self, report: StrategyReport) -> str:
+        """Generate an engaging article title.
+
+        Args:
+            report: The strategy report
+
+        Returns:
+            Generated title string
+        """
+        strategy_type_display = report.strategy_type.replace("_", " ").title()
+
+        # Extract key metrics
+        sharpe = report.backtest_results.get("sharpe_ratio", 0)
+        total_return = report.backtest_results.get("total_return", 0)
+
+        # Generate descriptive title
+        if sharpe >= 1.5:
+            performance = "High-Performance"
+        elif sharpe >= 1.0:
+            performance = "Strong"
+        elif sharpe >= 0.5:
+            performance = "Viable"
+        else:
+            performance = "Experimental"
+
+        return f"{performance} {strategy_type_display} Strategy: {report.strategy_name}"
+
+    def generate_summary(self, report: StrategyReport) -> str:
+        """Generate a concise strategy summary.
+
+        Uses LLM if available, otherwise creates a template-based summary.
+
+        Args:
+            report: The strategy report
+
+        Returns:
+            Summary text
+        """
+        if self.llm:
+            return self._generate_llm_summary(report)
+        else:
+            return self._generate_template_summary(report)
+
+    def _generate_template_summary(self, report: StrategyReport) -> str:
+        """Generate template-based summary."""
+        strategy_type = report.strategy_type.replace("_", " ")
+        sharpe = report.backtest_results.get("sharpe_ratio", 0)
+        total_return = report.backtest_results.get("total_return", 0)
+        drawdown = report.backtest_results.get("max_drawdown", 0)
+
+        # Determine strategy characteristics from code
+        code_content = "\n".join(report.code_files.values())
+
+        indicators = []
+        if "SMA" in code_content or "SimpleMovingAverage" in code_content:
+            indicators.append("Simple Moving Average")
+        if "EMA" in code_content or "ExponentialMovingAverage" in code_content:
+            indicators.append("Exponential Moving Average")
+        if "RSI" in code_content or "RelativeStrengthIndex" in code_content:
+            indicators.append("RSI")
+        if "MACD" in code_content:
+            indicators.append("MACD")
+        if "BollingerBands" in code_content:
+            indicators.append("Bollinger Bands")
+        if "ATR" in code_content or "AverageTrueRange" in code_content:
+            indicators.append("ATR")
+
+        indicators_text = ", ".join(indicators) if indicators else "custom indicators"
+
+        summary = f"""This {strategy_type} strategy was derived from the research paper "{report.paper_title}".
+
+The algorithm uses {indicators_text} to generate trading signals. """
+
+        if sharpe >= 1.0:
+            summary += f"Backtesting shows promising results with a Sharpe ratio of {sharpe:.2f}. "
+        else:
+            summary += f"Initial backtesting shows a Sharpe ratio of {sharpe:.2f}. "
+
+        if total_return > 0:
+            summary += f"The strategy achieved a total return of {total_return:.1%} "
+        else:
+            summary += f"The strategy had a return of {total_return:.1%} "
+
+        summary += f"with a maximum drawdown of {abs(drawdown):.1%}."
+
+        return summary
+
+    def _generate_llm_summary(self, report: StrategyReport) -> str:
+        """Generate LLM-enhanced summary."""
+        prompt = f"""Write a concise 2-3 paragraph summary of this trading strategy for a technical audience:
+
+Paper: {report.paper_title}
+Strategy Type: {report.strategy_type}
+Paper Abstract: {report.paper_abstract[:500]}
+
+Backtest Results:
+- Sharpe Ratio: {report.backtest_results.get('sharpe_ratio', 'N/A')}
+- Total Return: {report.backtest_results.get('total_return', 'N/A')}
+- Max Drawdown: {report.backtest_results.get('max_drawdown', 'N/A')}
+
+Code Preview:
+{list(report.code_files.values())[0][:500] if report.code_files else 'Not available'}
+
+Focus on:
+1. What the strategy does and how it works
+2. Key technical indicators or signals used
+3. Performance characteristics and risk profile
+
+Keep it factual and technical. No marketing language."""
+
+        try:
+            response = self.llm.generate(prompt, max_tokens=500)
+            return response.strip()
+        except Exception as e:
+            logger.warning(f"LLM summary generation failed: {e}, falling back to template")
+            return self._generate_template_summary(report)
+
+    def generate_notion_article(self, report: StrategyReport) -> StrategyArticle:
+        """Generate a StrategyArticle for Notion publishing.
+
+        Args:
+            report: The strategy report
+
+        Returns:
+            StrategyArticle ready for Notion
+        """
+        title = self.generate_title(report)
+        summary = self.generate_summary(report)
+
+        # Get main code file for snippet
+        main_code = report.code_files.get("Main.py", "")
+        if not main_code and report.code_files:
+            main_code = list(report.code_files.values())[0]
+
+        # Build QuantConnect URL if we have project info
+        qc_url = None
+        if report.quantconnect_project_id:
+            qc_url = f"https://www.quantconnect.com/project/{report.quantconnect_project_id}"
+
+        # Determine tags
+        tags = [report.strategy_type.replace("_", " ").title()]
+
+        # Add performance-based tags
+        sharpe = report.backtest_results.get("sharpe_ratio", 0)
+        if sharpe >= 1.5:
+            tags.append("High Sharpe")
+        if report.backtest_results.get("total_return", 0) > 0.5:
+            tags.append("High Return")
+        if abs(report.backtest_results.get("max_drawdown", 0)) < 0.1:
+            tags.append("Low Drawdown")
+
+        return StrategyArticle(
+            title=title,
+            paper_title=report.paper_title,
+            paper_url=report.paper_url,
+            paper_authors=report.paper_authors,
+            strategy_summary=summary,
+            strategy_type=report.strategy_type,
+            backtest_results=report.backtest_results,
+            code_snippet=main_code[:2000] if main_code else None,
+            quantconnect_project_url=qc_url,
+            tags=tags
+        )
+
+    def generate_markdown(self, report: StrategyReport) -> str:
+        """Generate a markdown article for local storage.
+
+        Args:
+            report: The strategy report
+
+        Returns:
+            Markdown formatted article
+        """
+        title = self.generate_title(report)
+        summary = self.generate_summary(report)
+        results = report.backtest_results
+
+        md = f"""# {title}
+
+> Based on: [{report.paper_title}]({report.paper_url})
+> Authors: {', '.join(report.paper_authors)}
+> Generated: {report.generated_at.strftime('%Y-%m-%d %H:%M')}
+
+## Strategy Summary
+
+{summary}
+
+## Backtest Results
+
+| Metric | Value |
+|--------|-------|
+| Sharpe Ratio | {results.get('sharpe_ratio', 'N/A'):.2f} |
+| Total Return | {results.get('total_return', 0):.2%} |
+| Max Drawdown | {results.get('max_drawdown', 0):.2%} |
+| Win Rate | {results.get('win_rate', 'N/A')} |
+| Period | {results.get('start_date', 'N/A')} to {results.get('end_date', 'N/A')} |
+
+"""
+
+        # Add QuantConnect link if available
+        if report.quantconnect_project_id:
+            md += f"""## Algorithm
+
+[View on QuantConnect](https://www.quantconnect.com/project/{report.quantconnect_project_id})
+
+"""
+
+        # Add code files
+        md += "## Code\n\n"
+        for filename, code in report.code_files.items():
+            md += f"### {filename}\n\n```python\n{code}\n```\n\n"
+
+        md += """---
+
+*Generated by QuantCoder - AI-powered algorithmic trading strategy generator*
+"""
+
+        return md
+
+    def save_markdown(self, report: StrategyReport, output_dir: Path) -> Path:
+        """Save markdown article to file.
+
+        Args:
+            report: The strategy report
+            output_dir: Directory to save to
+
+        Returns:
+            Path to saved file
+        """
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        filename = f"{report.strategy_name}_{report.generated_at.strftime('%Y%m%d_%H%M%S')}.md"
+        filepath = output_dir / filename
+
+        md_content = self.generate_markdown(report)
+        filepath.write_text(md_content, encoding="utf-8")
+
+        logger.info(f"Saved markdown article to {filepath}")
+        return filepath
+
+    def save_json_report(self, report: StrategyReport, output_dir: Path) -> Path:
+        """Save complete report as JSON.
+
+        Args:
+            report: The strategy report
+            output_dir: Directory to save to
+
+        Returns:
+            Path to saved file
+        """
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        filename = f"{report.strategy_name}_{report.generated_at.strftime('%Y%m%d_%H%M%S')}.json"
+        filepath = output_dir / filename
+
+        data = {
+            "strategy_name": report.strategy_name,
+            "paper": {
+                "title": report.paper_title,
+                "url": report.paper_url,
+                "authors": report.paper_authors,
+                "abstract": report.paper_abstract
+            },
+            "strategy": {
+                "type": report.strategy_type,
+                "summary": self.generate_summary(report)
+            },
+            "code_files": report.code_files,
+            "backtest_results": report.backtest_results,
+            "quantconnect": {
+                "project_id": report.quantconnect_project_id,
+                "backtest_id": report.quantconnect_backtest_id
+            },
+            "generated_at": report.generated_at.isoformat()
+        }
+
+        filepath.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+        logger.info(f"Saved JSON report to {filepath}")
+        return filepath

--- a/quantcoder/scheduler/automated_pipeline.py
+++ b/quantcoder/scheduler/automated_pipeline.py
@@ -52,6 +52,11 @@ class PipelineConfig:
     publish_to_notion: bool = True
     notion_min_sharpe: float = 0.5  # Same as acceptance criteria by default
 
+    # Evolution settings - evolve strategies after backtest passes
+    evolve_strategies: bool = False  # Enable evolution for passing strategies
+    evolution_generations: int = 5  # Number of generations to evolve
+    evolution_variants: int = 3  # Variants per generation
+
     # Paper tracking (avoid reprocessing)
     processed_papers_file: Path = field(default_factory=lambda: Path.home() / ".quantcoder" / "processed_papers.json")
 

--- a/quantcoder/scheduler/automated_pipeline.py
+++ b/quantcoder/scheduler/automated_pipeline.py
@@ -33,11 +33,11 @@ class PipelineConfig:
         "factor investing",
         "machine learning trading"
     ])
-    papers_per_query: int = 3
+    papers_per_query: int = 5
 
-    # Strategy selection
-    min_sharpe_ratio: float = 0.5
-    max_strategies_per_run: int = 3
+    # Strategy selection - batch limit for strategies per run
+    min_sharpe_ratio: float = 0.5  # Acceptance criteria for keeping algo
+    max_strategies_per_run: int = 10  # Batch limit (configurable)
 
     # Backtest configuration
     backtest_start_date: str = "2020-01-01"
@@ -48,9 +48,9 @@ class PipelineConfig:
     save_markdown: bool = True
     save_json: bool = True
 
-    # Notion publishing
+    # Notion publishing - articles for successful strategies only
     publish_to_notion: bool = True
-    notion_min_sharpe: float = 0.8  # Higher bar for publishing
+    notion_min_sharpe: float = 0.5  # Same as acceptance criteria by default
 
     # Paper tracking (avoid reprocessing)
     processed_papers_file: Path = field(default_factory=lambda: Path.home() / ".quantcoder" / "processed_papers.json")

--- a/quantcoder/scheduler/automated_pipeline.py
+++ b/quantcoder/scheduler/automated_pipeline.py
@@ -1,0 +1,447 @@
+"""Automated end-to-end pipeline for strategy generation and publishing."""
+
+import asyncio
+import json
+import logging
+from datetime import datetime, timedelta
+from typing import Optional, Dict, List, Any
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from rich.console import Console
+from rich.panel import Panel
+from rich.progress import Progress, SpinnerColumn, TextColumn
+
+from quantcoder.config import Config
+from quantcoder.autonomous.pipeline import AutonomousPipeline
+from quantcoder.autonomous.database import LearningDatabase
+from .notion_client import NotionClient, StrategyArticle
+from .article_generator import ArticleGenerator, StrategyReport
+
+logger = logging.getLogger(__name__)
+console = Console()
+
+
+@dataclass
+class PipelineConfig:
+    """Configuration for the automated pipeline."""
+    # Search configuration
+    search_queries: List[str] = field(default_factory=lambda: [
+        "momentum trading strategy",
+        "mean reversion trading",
+        "statistical arbitrage",
+        "factor investing",
+        "machine learning trading"
+    ])
+    papers_per_query: int = 3
+
+    # Strategy selection
+    min_sharpe_ratio: float = 0.5
+    max_strategies_per_run: int = 3
+
+    # Backtest configuration
+    backtest_start_date: str = "2020-01-01"
+    backtest_end_date: str = "2024-01-01"
+
+    # Output configuration
+    output_dir: Path = field(default_factory=lambda: Path.home() / ".quantcoder" / "automated_strategies")
+    save_markdown: bool = True
+    save_json: bool = True
+
+    # Notion publishing
+    publish_to_notion: bool = True
+    notion_min_sharpe: float = 0.8  # Higher bar for publishing
+
+    # Paper tracking (avoid reprocessing)
+    processed_papers_file: Path = field(default_factory=lambda: Path.home() / ".quantcoder" / "processed_papers.json")
+
+
+@dataclass
+class PipelineResult:
+    """Result of a pipeline run."""
+    run_id: str
+    started_at: datetime
+    completed_at: Optional[datetime] = None
+    papers_found: int = 0
+    papers_processed: int = 0
+    strategies_generated: int = 0
+    strategies_passed_backtest: int = 0
+    strategies_published: int = 0
+    best_strategy: Optional[Dict] = None
+    errors: List[str] = field(default_factory=list)
+
+    @property
+    def duration(self) -> Optional[timedelta]:
+        if self.completed_at:
+            return self.completed_at - self.started_at
+        return None
+
+    def to_dict(self) -> Dict:
+        return {
+            "run_id": self.run_id,
+            "started_at": self.started_at.isoformat(),
+            "completed_at": self.completed_at.isoformat() if self.completed_at else None,
+            "duration_seconds": self.duration.total_seconds() if self.duration else None,
+            "papers_found": self.papers_found,
+            "papers_processed": self.papers_processed,
+            "strategies_generated": self.strategies_generated,
+            "strategies_passed_backtest": self.strategies_passed_backtest,
+            "strategies_published": self.strategies_published,
+            "best_strategy": self.best_strategy,
+            "errors": self.errors
+        }
+
+
+class AutomatedBacktestPipeline:
+    """Fully automated pipeline: Papers -> Strategies -> Backtest -> Notion."""
+
+    def __init__(
+        self,
+        config: Optional[Config] = None,
+        pipeline_config: Optional[PipelineConfig] = None,
+        notion_client: Optional[NotionClient] = None
+    ):
+        """Initialize the automated pipeline.
+
+        Args:
+            config: QuantCoder configuration
+            pipeline_config: Pipeline-specific configuration
+            notion_client: Pre-configured Notion client (optional)
+        """
+        self.config = config or Config.load()
+        self.pipeline_config = pipeline_config or PipelineConfig()
+
+        # Initialize components
+        self.autonomous = AutonomousPipeline(config=self.config, demo_mode=False)
+        self.article_generator = ArticleGenerator()
+
+        # Initialize Notion client
+        if notion_client:
+            self.notion = notion_client
+        else:
+            self.notion = NotionClient()
+
+        # Track processed papers
+        self.processed_papers = self._load_processed_papers()
+
+    def _load_processed_papers(self) -> set:
+        """Load set of already processed paper URLs/DOIs."""
+        papers_file = self.pipeline_config.processed_papers_file
+        if papers_file.exists():
+            try:
+                with open(papers_file, 'r') as f:
+                    data = json.load(f)
+                return set(data.get("processed", []))
+            except Exception as e:
+                logger.warning(f"Could not load processed papers: {e}")
+        return set()
+
+    def _save_processed_papers(self):
+        """Save processed papers to file."""
+        papers_file = self.pipeline_config.processed_papers_file
+        try:
+            papers_file.parent.mkdir(parents=True, exist_ok=True)
+            with open(papers_file, 'w') as f:
+                json.dump({"processed": list(self.processed_papers)}, f)
+        except Exception as e:
+            logger.warning(f"Could not save processed papers: {e}")
+
+    def _mark_paper_processed(self, paper: Dict):
+        """Mark a paper as processed."""
+        identifier = paper.get('doi') or paper.get('url') or paper.get('title')
+        if identifier:
+            self.processed_papers.add(identifier)
+            self._save_processed_papers()
+
+    def _is_paper_processed(self, paper: Dict) -> bool:
+        """Check if a paper has already been processed."""
+        identifier = paper.get('doi') or paper.get('url') or paper.get('title')
+        return identifier in self.processed_papers if identifier else False
+
+    async def run(self) -> PipelineResult:
+        """Execute the full automated pipeline.
+
+        Returns:
+            PipelineResult with run statistics
+        """
+        run_id = datetime.now().strftime("%Y%m%d_%H%M%S")
+        result = PipelineResult(
+            run_id=run_id,
+            started_at=datetime.now()
+        )
+
+        console.print(Panel.fit(
+            f"[bold cyan]Automated Strategy Pipeline[/bold cyan]\n\n"
+            f"Run ID: {run_id}\n"
+            f"Queries: {len(self.pipeline_config.search_queries)}\n"
+            f"Min Sharpe: {self.pipeline_config.min_sharpe_ratio}\n"
+            f"Publish to Notion: {self.pipeline_config.publish_to_notion}",
+            title="Starting Pipeline"
+        ))
+
+        try:
+            # Step 1: Discover papers
+            console.print("\n[cyan]Step 1: Discovering research papers...[/cyan]")
+            all_papers = await self._discover_papers()
+            result.papers_found = len(all_papers)
+            console.print(f"[green]Found {len(all_papers)} papers[/green]")
+
+            # Filter out already processed papers
+            new_papers = [p for p in all_papers if not self._is_paper_processed(p)]
+            console.print(f"[dim]New papers to process: {len(new_papers)}[/dim]")
+
+            if not new_papers:
+                console.print("[yellow]No new papers to process[/yellow]")
+                result.completed_at = datetime.now()
+                return result
+
+            # Step 2: Generate and backtest strategies
+            console.print("\n[cyan]Step 2: Generating and backtesting strategies...[/cyan]")
+            successful_strategies = []
+
+            for i, paper in enumerate(new_papers[:self.pipeline_config.max_strategies_per_run * 2]):
+                console.print(f"\n[dim]Processing paper {i+1}/{min(len(new_papers), self.pipeline_config.max_strategies_per_run * 2)}[/dim]")
+                console.print(f"[bold]{paper.get('title', 'Unknown')[:80]}...[/bold]")
+
+                try:
+                    strategy_result = await self._process_paper(paper)
+                    result.papers_processed += 1
+
+                    if strategy_result:
+                        result.strategies_generated += 1
+
+                        # Check if it passes our threshold
+                        sharpe = strategy_result.get('backtest_results', {}).get('sharpe_ratio', 0)
+                        if sharpe >= self.pipeline_config.min_sharpe_ratio:
+                            result.strategies_passed_backtest += 1
+                            successful_strategies.append(strategy_result)
+                            console.print(f"[green]Strategy passed with Sharpe {sharpe:.2f}[/green]")
+
+                            # Track best strategy
+                            if not result.best_strategy or sharpe > result.best_strategy.get('sharpe_ratio', 0):
+                                result.best_strategy = {
+                                    'name': strategy_result['name'],
+                                    'sharpe_ratio': sharpe,
+                                    'paper_title': paper.get('title')
+                                }
+                        else:
+                            console.print(f"[yellow]Strategy below threshold (Sharpe {sharpe:.2f})[/yellow]")
+
+                    self._mark_paper_processed(paper)
+
+                    # Stop if we have enough successful strategies
+                    if len(successful_strategies) >= self.pipeline_config.max_strategies_per_run:
+                        console.print(f"\n[green]Reached target of {self.pipeline_config.max_strategies_per_run} strategies[/green]")
+                        break
+
+                except Exception as e:
+                    error_msg = f"Error processing paper: {e}"
+                    logger.error(error_msg)
+                    result.errors.append(error_msg)
+                    console.print(f"[red]{error_msg}[/red]")
+
+            # Step 3: Generate articles and publish to Notion
+            if successful_strategies:
+                console.print(f"\n[cyan]Step 3: Publishing {len(successful_strategies)} strategies...[/cyan]")
+
+                for strategy in successful_strategies:
+                    try:
+                        published = await self._publish_strategy(strategy)
+                        if published:
+                            result.strategies_published += 1
+                            console.print(f"[green]Published: {strategy['name']}[/green]")
+                    except Exception as e:
+                        error_msg = f"Error publishing strategy: {e}"
+                        logger.error(error_msg)
+                        result.errors.append(error_msg)
+
+        except Exception as e:
+            error_msg = f"Pipeline error: {e}"
+            logger.error(error_msg)
+            result.errors.append(error_msg)
+            console.print(f"[red]{error_msg}[/red]")
+
+        result.completed_at = datetime.now()
+
+        # Print summary
+        self._print_summary(result)
+
+        return result
+
+    async def _discover_papers(self) -> List[Dict]:
+        """Discover papers from configured search queries."""
+        all_papers = []
+
+        for query in self.pipeline_config.search_queries:
+            try:
+                # Use the autonomous pipeline's paper fetching
+                papers = await self.autonomous._fetch_papers(
+                    query,
+                    limit=self.pipeline_config.papers_per_query
+                )
+                all_papers.extend(papers)
+                console.print(f"  [dim]'{query}': {len(papers)} papers[/dim]")
+            except Exception as e:
+                logger.warning(f"Error fetching papers for '{query}': {e}")
+
+        # Deduplicate by URL/DOI
+        seen = set()
+        unique_papers = []
+        for paper in all_papers:
+            identifier = paper.get('doi') or paper.get('url') or paper.get('title')
+            if identifier and identifier not in seen:
+                seen.add(identifier)
+                unique_papers.append(paper)
+
+        return unique_papers
+
+    async def _process_paper(self, paper: Dict) -> Optional[Dict]:
+        """Process a single paper: generate strategy and backtest.
+
+        Returns:
+            Strategy result dict if successful, None otherwise
+        """
+        # Generate strategy using the autonomous pipeline's method
+        enhanced_prompts = self.autonomous.prompt_refiner.get_enhanced_prompts_for_agents(
+            strategy_type=self.autonomous._extract_strategy_type(paper.get('title', ''))
+        )
+
+        strategy = await self.autonomous._generate_strategy(paper, enhanced_prompts)
+
+        if not strategy:
+            return None
+
+        # Validate
+        validation_result = await self.autonomous._validate_and_learn(strategy, iteration=1)
+
+        if not validation_result['valid']:
+            # Try self-healing
+            strategy = await self.autonomous._apply_learned_fixes(strategy, validation_result['errors'])
+            validation_result = await self.autonomous._validate_and_learn(strategy, iteration=1)
+
+            if not validation_result['valid']:
+                logger.warning(f"Strategy validation failed for {paper.get('title', 'unknown')}")
+                return None
+
+        # Backtest
+        backtest_result = await self.autonomous._backtest(strategy)
+
+        # Build complete result
+        return {
+            'name': strategy['name'],
+            'paper': paper,
+            'code_files': strategy.get('code_files', {}),
+            'code': strategy.get('code', ''),
+            'backtest_results': backtest_result,
+            'strategy_type': self.autonomous._extract_strategy_type(paper.get('title', ''))
+        }
+
+    async def _publish_strategy(self, strategy: Dict) -> bool:
+        """Publish strategy to Notion and save locally.
+
+        Returns:
+            True if published successfully
+        """
+        paper = strategy['paper']
+        backtest = strategy['backtest_results']
+
+        # Create strategy report
+        report = StrategyReport(
+            strategy_name=strategy['name'],
+            paper_title=paper.get('title', 'Unknown'),
+            paper_url=paper.get('url', ''),
+            paper_authors=paper.get('authors', []),
+            paper_abstract=paper.get('abstract', ''),
+            strategy_type=strategy['strategy_type'],
+            strategy_summary='',  # Will be generated
+            code_files=strategy.get('code_files', {}),
+            backtest_results=backtest,
+            quantconnect_project_id=backtest.get('project_id'),
+            quantconnect_backtest_id=backtest.get('backtest_id')
+        )
+
+        # Save locally
+        output_dir = self.pipeline_config.output_dir / strategy['name']
+
+        if self.pipeline_config.save_markdown:
+            self.article_generator.save_markdown(report, output_dir)
+
+        if self.pipeline_config.save_json:
+            self.article_generator.save_json_report(report, output_dir)
+
+        # Save code files
+        output_dir.mkdir(parents=True, exist_ok=True)
+        for filename, code in strategy.get('code_files', {}).items():
+            if code:
+                (output_dir / filename).write_text(code, encoding='utf-8')
+
+        # Publish to Notion if configured and meets threshold
+        if self.pipeline_config.publish_to_notion:
+            sharpe = backtest.get('sharpe_ratio', 0)
+
+            if sharpe >= self.pipeline_config.notion_min_sharpe:
+                if self.notion.is_configured():
+                    article = self.article_generator.generate_notion_article(report)
+                    notion_page = self.notion.create_strategy_page(article)
+
+                    if notion_page:
+                        console.print(f"[green]Published to Notion: {notion_page.url}[/green]")
+                        return True
+                    else:
+                        console.print("[yellow]Failed to publish to Notion[/yellow]")
+                else:
+                    console.print("[yellow]Notion not configured, skipping publish[/yellow]")
+            else:
+                console.print(f"[dim]Sharpe {sharpe:.2f} below Notion threshold ({self.pipeline_config.notion_min_sharpe})[/dim]")
+
+        return True  # Local save counts as success
+
+    def _print_summary(self, result: PipelineResult):
+        """Print pipeline run summary."""
+        from rich.table import Table
+
+        console.print("\n" + "=" * 60)
+        console.print("[bold cyan]Pipeline Run Complete[/bold cyan]")
+        console.print("=" * 60 + "\n")
+
+        table = Table(title="Run Summary")
+        table.add_column("Metric", style="cyan")
+        table.add_column("Value", style="green")
+
+        table.add_row("Run ID", result.run_id)
+        table.add_row("Duration", str(result.duration) if result.duration else "N/A")
+        table.add_row("Papers Found", str(result.papers_found))
+        table.add_row("Papers Processed", str(result.papers_processed))
+        table.add_row("Strategies Generated", str(result.strategies_generated))
+        table.add_row("Passed Backtest", str(result.strategies_passed_backtest))
+        table.add_row("Published to Notion", str(result.strategies_published))
+
+        if result.best_strategy:
+            table.add_row("Best Strategy", f"{result.best_strategy['name']} (Sharpe: {result.best_strategy['sharpe_ratio']:.2f})")
+
+        console.print(table)
+
+        if result.errors:
+            console.print(f"\n[yellow]Errors ({len(result.errors)}):[/yellow]")
+            for err in result.errors[:5]:
+                console.print(f"  [red]- {err}[/red]")
+
+
+async def run_automated_pipeline(
+    config: Optional[Config] = None,
+    pipeline_config: Optional[PipelineConfig] = None
+) -> Dict[str, Any]:
+    """Convenience function to run the automated pipeline.
+
+    Returns:
+        Dict with run statistics for the scheduler
+    """
+    pipeline = AutomatedBacktestPipeline(config=config, pipeline_config=pipeline_config)
+    result = await pipeline.run()
+
+    return {
+        "strategies_generated": result.strategies_generated,
+        "strategies_published": result.strategies_published,
+        "success": len(result.errors) == 0,
+        "result": result.to_dict()
+    }

--- a/quantcoder/scheduler/runner.py
+++ b/quantcoder/scheduler/runner.py
@@ -1,0 +1,329 @@
+"""Scheduled runner for automated strategy generation."""
+
+import asyncio
+import logging
+import signal
+import sys
+from datetime import datetime, timedelta
+from typing import Optional, Callable, Any
+from dataclasses import dataclass, field
+from pathlib import Path
+from enum import Enum
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.cron import CronTrigger
+from apscheduler.triggers.interval import IntervalTrigger
+from rich.console import Console
+
+logger = logging.getLogger(__name__)
+console = Console()
+
+
+class ScheduleInterval(Enum):
+    """Predefined schedule intervals."""
+    HOURLY = "hourly"
+    DAILY = "daily"
+    WEEKLY = "weekly"
+    CUSTOM = "custom"
+
+
+@dataclass
+class ScheduleConfig:
+    """Configuration for scheduled runs."""
+    interval: ScheduleInterval = ScheduleInterval.DAILY
+    cron_expression: Optional[str] = None  # For custom schedules
+    hour: int = 6  # Default run at 6 AM for daily
+    minute: int = 0
+    day_of_week: str = "mon"  # For weekly runs
+    timezone: str = "UTC"
+    max_runs: Optional[int] = None  # None = unlimited
+    enabled: bool = True
+
+    def to_trigger(self):
+        """Convert config to APScheduler trigger."""
+        if self.interval == ScheduleInterval.CUSTOM and self.cron_expression:
+            return CronTrigger.from_crontab(self.cron_expression, timezone=self.timezone)
+        elif self.interval == ScheduleInterval.HOURLY:
+            return IntervalTrigger(hours=1, timezone=self.timezone)
+        elif self.interval == ScheduleInterval.DAILY:
+            return CronTrigger(hour=self.hour, minute=self.minute, timezone=self.timezone)
+        elif self.interval == ScheduleInterval.WEEKLY:
+            return CronTrigger(
+                day_of_week=self.day_of_week,
+                hour=self.hour,
+                minute=self.minute,
+                timezone=self.timezone
+            )
+        else:
+            return IntervalTrigger(hours=24, timezone=self.timezone)
+
+
+@dataclass
+class RunStats:
+    """Statistics for scheduler runs."""
+    total_runs: int = 0
+    successful_runs: int = 0
+    failed_runs: int = 0
+    strategies_generated: int = 0
+    strategies_published: int = 0
+    last_run_time: Optional[datetime] = None
+    last_run_success: bool = True
+    errors: list = field(default_factory=list)
+
+    @property
+    def success_rate(self) -> float:
+        if self.total_runs == 0:
+            return 0.0
+        return self.successful_runs / self.total_runs
+
+
+class ScheduledRunner:
+    """Manages scheduled execution of the automated pipeline."""
+
+    def __init__(
+        self,
+        pipeline_func: Callable,
+        schedule_config: Optional[ScheduleConfig] = None,
+        state_file: Optional[Path] = None
+    ):
+        """Initialize scheduled runner.
+
+        Args:
+            pipeline_func: Async function to run on schedule
+            schedule_config: Schedule configuration
+            state_file: Path to persist state between runs
+        """
+        self.pipeline_func = pipeline_func
+        self.config = schedule_config or ScheduleConfig()
+        self.state_file = state_file or Path.home() / ".quantcoder" / "scheduler_state.json"
+
+        self.scheduler = AsyncIOScheduler(timezone=self.config.timezone)
+        self.stats = RunStats()
+        self.running = False
+
+        # Callbacks
+        self.on_run_start: Optional[Callable] = None
+        self.on_run_complete: Optional[Callable[[bool, Any], None]] = None
+        self.on_error: Optional[Callable[[Exception], None]] = None
+
+        # Load persisted state
+        self._load_state()
+
+    def _load_state(self):
+        """Load persisted state from file."""
+        if self.state_file.exists():
+            try:
+                import json
+                with open(self.state_file, 'r') as f:
+                    data = json.load(f)
+                self.stats.total_runs = data.get("total_runs", 0)
+                self.stats.successful_runs = data.get("successful_runs", 0)
+                self.stats.failed_runs = data.get("failed_runs", 0)
+                self.stats.strategies_generated = data.get("strategies_generated", 0)
+                self.stats.strategies_published = data.get("strategies_published", 0)
+                if data.get("last_run_time"):
+                    self.stats.last_run_time = datetime.fromisoformat(data["last_run_time"])
+                logger.info(f"Loaded scheduler state: {self.stats.total_runs} previous runs")
+            except Exception as e:
+                logger.warning(f"Could not load scheduler state: {e}")
+
+    def _save_state(self):
+        """Save state to file."""
+        try:
+            import json
+            self.state_file.parent.mkdir(parents=True, exist_ok=True)
+            data = {
+                "total_runs": self.stats.total_runs,
+                "successful_runs": self.stats.successful_runs,
+                "failed_runs": self.stats.failed_runs,
+                "strategies_generated": self.stats.strategies_generated,
+                "strategies_published": self.stats.strategies_published,
+                "last_run_time": self.stats.last_run_time.isoformat() if self.stats.last_run_time else None,
+                "last_run_success": self.stats.last_run_success
+            }
+            with open(self.state_file, 'w') as f:
+                json.dump(data, f, indent=2)
+        except Exception as e:
+            logger.warning(f"Could not save scheduler state: {e}")
+
+    async def _execute_run(self):
+        """Execute a single scheduled run."""
+        run_start = datetime.now()
+        self.stats.total_runs += 1
+        self.stats.last_run_time = run_start
+
+        console.print(f"\n[bold cyan]{'=' * 60}[/bold cyan]")
+        console.print(f"[bold cyan]Scheduled Run #{self.stats.total_runs}[/bold cyan]")
+        console.print(f"[dim]Started: {run_start.strftime('%Y-%m-%d %H:%M:%S')}[/dim]")
+        console.print(f"[bold cyan]{'=' * 60}[/bold cyan]\n")
+
+        if self.on_run_start:
+            self.on_run_start()
+
+        try:
+            # Execute the pipeline
+            result = await self.pipeline_func()
+
+            # Update stats from result
+            if result:
+                self.stats.strategies_generated += result.get("strategies_generated", 0)
+                self.stats.strategies_published += result.get("strategies_published", 0)
+
+            self.stats.successful_runs += 1
+            self.stats.last_run_success = True
+
+            elapsed = datetime.now() - run_start
+            console.print(f"\n[green]Run #{self.stats.total_runs} completed successfully[/green]")
+            console.print(f"[dim]Duration: {elapsed}[/dim]")
+
+            if self.on_run_complete:
+                self.on_run_complete(True, result)
+
+        except Exception as e:
+            self.stats.failed_runs += 1
+            self.stats.last_run_success = False
+            self.stats.errors.append({
+                "time": run_start.isoformat(),
+                "error": str(e)
+            })
+
+            logger.error(f"Scheduled run failed: {e}")
+            console.print(f"\n[red]Run #{self.stats.total_runs} failed: {e}[/red]")
+
+            if self.on_error:
+                self.on_error(e)
+
+            if self.on_run_complete:
+                self.on_run_complete(False, None)
+
+        finally:
+            self._save_state()
+
+            # Check if we've hit max runs
+            if self.config.max_runs and self.stats.total_runs >= self.config.max_runs:
+                console.print(f"\n[yellow]Reached maximum runs ({self.config.max_runs}). Stopping scheduler.[/yellow]")
+                self.stop()
+
+    def start(self):
+        """Start the scheduler."""
+        if self.running:
+            logger.warning("Scheduler is already running")
+            return
+
+        if not self.config.enabled:
+            logger.warning("Scheduler is disabled in configuration")
+            return
+
+        # Set up signal handlers
+        signal.signal(signal.SIGINT, self._handle_shutdown)
+        signal.signal(signal.SIGTERM, self._handle_shutdown)
+
+        # Add job to scheduler
+        trigger = self.config.to_trigger()
+        self.scheduler.add_job(
+            self._execute_run,
+            trigger=trigger,
+            id="automated_pipeline",
+            name="Automated Strategy Pipeline",
+            replace_existing=True
+        )
+
+        # Start scheduler
+        self.scheduler.start()
+        self.running = True
+
+        # Calculate next run time
+        job = self.scheduler.get_job("automated_pipeline")
+        next_run = job.next_run_time if job else None
+
+        console.print(f"\n[green]Scheduler started[/green]")
+        console.print(f"[cyan]Schedule:[/cyan] {self.config.interval.value}")
+        if next_run:
+            console.print(f"[cyan]Next run:[/cyan] {next_run.strftime('%Y-%m-%d %H:%M:%S %Z')}")
+        console.print(f"[dim]Press Ctrl+C to stop[/dim]\n")
+
+        logger.info(f"Scheduler started with {self.config.interval.value} schedule")
+
+    def stop(self):
+        """Stop the scheduler gracefully."""
+        if not self.running:
+            return
+
+        console.print("\n[yellow]Stopping scheduler...[/yellow]")
+        self.scheduler.shutdown(wait=True)
+        self.running = False
+        self._save_state()
+
+        console.print("[green]Scheduler stopped[/green]")
+        logger.info("Scheduler stopped")
+
+    def _handle_shutdown(self, signum, frame):
+        """Handle shutdown signals."""
+        console.print("\n[yellow]Received shutdown signal[/yellow]")
+        self.stop()
+        sys.exit(0)
+
+    async def run_once(self):
+        """Run the pipeline once immediately (for testing)."""
+        console.print("[cyan]Running pipeline once...[/cyan]")
+        await self._execute_run()
+
+    async def run_forever(self):
+        """Run the scheduler indefinitely."""
+        self.start()
+        try:
+            while self.running:
+                await asyncio.sleep(1)
+        except KeyboardInterrupt:
+            self.stop()
+
+    def get_status(self) -> dict:
+        """Get current scheduler status."""
+        job = self.scheduler.get_job("automated_pipeline") if self.running else None
+
+        return {
+            "running": self.running,
+            "enabled": self.config.enabled,
+            "schedule": self.config.interval.value,
+            "next_run": job.next_run_time.isoformat() if job and job.next_run_time else None,
+            "stats": {
+                "total_runs": self.stats.total_runs,
+                "successful_runs": self.stats.successful_runs,
+                "failed_runs": self.stats.failed_runs,
+                "success_rate": f"{self.stats.success_rate:.1%}",
+                "strategies_generated": self.stats.strategies_generated,
+                "strategies_published": self.stats.strategies_published,
+                "last_run": self.stats.last_run_time.isoformat() if self.stats.last_run_time else None,
+                "last_run_success": self.stats.last_run_success
+            }
+        }
+
+    def print_status(self):
+        """Print scheduler status to console."""
+        from rich.table import Table
+        from rich.panel import Panel
+
+        status = self.get_status()
+
+        # Status panel
+        status_text = f"""[bold]Running:[/bold] {'Yes' if status['running'] else 'No'}
+[bold]Schedule:[/bold] {status['schedule']}
+[bold]Next Run:[/bold] {status['next_run'] or 'Not scheduled'}"""
+
+        console.print(Panel(status_text, title="Scheduler Status", border_style="cyan"))
+
+        # Stats table
+        table = Table(title="Run Statistics")
+        table.add_column("Metric", style="cyan")
+        table.add_column("Value", style="green")
+
+        stats = status['stats']
+        table.add_row("Total Runs", str(stats['total_runs']))
+        table.add_row("Successful", str(stats['successful_runs']))
+        table.add_row("Failed", str(stats['failed_runs']))
+        table.add_row("Success Rate", stats['success_rate'])
+        table.add_row("Strategies Generated", str(stats['strategies_generated']))
+        table.add_row("Strategies Published", str(stats['strategies_published']))
+        table.add_row("Last Run", stats['last_run'] or "Never")
+
+        console.print(table)

--- a/quantcoder/tools/__init__.py
+++ b/quantcoder/tools/__init__.py
@@ -4,6 +4,7 @@ from .base import Tool, ToolResult
 from .article_tools import SearchArticlesTool, DownloadArticleTool, SummarizeArticleTool
 from .code_tools import GenerateCodeTool, ValidateCodeTool, BacktestTool
 from .file_tools import ReadFileTool, WriteFileTool
+from .deep_search import DeepSearchTool, TavilyClient
 
 __all__ = [
     "Tool",
@@ -16,4 +17,6 @@ __all__ = [
     "BacktestTool",
     "ReadFileTool",
     "WriteFileTool",
+    "DeepSearchTool",
+    "TavilyClient",
 ]

--- a/quantcoder/tools/deep_search.py
+++ b/quantcoder/tools/deep_search.py
@@ -1,0 +1,325 @@
+"""Deep search using Tavily API for high-quality research discovery."""
+
+import os
+import logging
+from typing import Dict, List, Optional, Any
+from dataclasses import dataclass
+
+import requests
+
+from .base import Tool, ToolResult
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SearchResult:
+    """A single search result from Tavily."""
+    title: str
+    url: str
+    content: str  # Extracted content/snippet
+    score: float  # Relevance score
+    published_date: Optional[str] = None
+
+    def to_dict(self) -> Dict:
+        return {
+            "title": self.title,
+            "url": self.url,
+            "content": self.content,
+            "score": self.score,
+            "published_date": self.published_date,
+        }
+
+
+class TavilyClient:
+    """Client for Tavily Search API."""
+
+    BASE_URL = "https://api.tavily.com"
+
+    def __init__(self, api_key: Optional[str] = None):
+        """Initialize Tavily client.
+
+        Args:
+            api_key: Tavily API key. Falls back to TAVILY_API_KEY env var.
+        """
+        self.api_key = api_key or os.getenv("TAVILY_API_KEY")
+
+        if not self.api_key:
+            logger.warning("Tavily API key not configured. Set TAVILY_API_KEY environment variable.")
+
+    def is_configured(self) -> bool:
+        """Check if client is properly configured."""
+        return bool(self.api_key)
+
+    def search(
+        self,
+        query: str,
+        search_depth: str = "advanced",
+        max_results: int = 10,
+        include_domains: Optional[List[str]] = None,
+        exclude_domains: Optional[List[str]] = None,
+        include_answer: bool = False,
+        include_raw_content: bool = False,
+    ) -> List[SearchResult]:
+        """Search using Tavily API.
+
+        Args:
+            query: Search query
+            search_depth: "basic" or "advanced" (more thorough)
+            max_results: Maximum number of results
+            include_domains: Only include results from these domains
+            exclude_domains: Exclude results from these domains
+            include_answer: Include AI-generated answer summary
+            include_raw_content: Include full page content
+
+        Returns:
+            List of SearchResult objects
+        """
+        if not self.api_key:
+            logger.error("Tavily API key not configured")
+            return []
+
+        payload = {
+            "api_key": self.api_key,
+            "query": query,
+            "search_depth": search_depth,
+            "max_results": max_results,
+            "include_answer": include_answer,
+            "include_raw_content": include_raw_content,
+        }
+
+        if include_domains:
+            payload["include_domains"] = include_domains
+        if exclude_domains:
+            payload["exclude_domains"] = exclude_domains
+
+        try:
+            response = requests.post(
+                f"{self.BASE_URL}/search",
+                json=payload,
+                timeout=30
+            )
+            response.raise_for_status()
+            data = response.json()
+
+            results = []
+            for item in data.get("results", []):
+                results.append(SearchResult(
+                    title=item.get("title", ""),
+                    url=item.get("url", ""),
+                    content=item.get("content", ""),
+                    score=item.get("score", 0.0),
+                    published_date=item.get("published_date"),
+                ))
+
+            return results
+
+        except requests.exceptions.RequestException as e:
+            logger.error(f"Tavily search failed: {e}")
+            return []
+
+    def search_research_papers(
+        self,
+        query: str,
+        max_results: int = 10,
+    ) -> List[SearchResult]:
+        """Search specifically for research papers and academic content.
+
+        Args:
+            query: Search query
+            max_results: Maximum number of results
+
+        Returns:
+            List of SearchResult objects
+        """
+        # Enhance query for academic/research content
+        enhanced_query = f"{query} research paper quantitative trading strategy backtest"
+
+        # Focus on academic and research domains
+        include_domains = [
+            "arxiv.org",
+            "ssrn.com",
+            "papers.ssrn.com",
+            "scholar.google.com",
+            "researchgate.net",
+            "sciencedirect.com",
+            "springer.com",
+            "wiley.com",
+            "tandfonline.com",
+            "jstor.org",
+            "nber.org",
+        ]
+
+        return self.search(
+            query=enhanced_query,
+            search_depth="advanced",
+            max_results=max_results,
+            include_domains=include_domains,
+        )
+
+
+class DeepSearchTool(Tool):
+    """Tool for deep research paper discovery using Tavily."""
+
+    @property
+    def name(self) -> str:
+        return "deep_search"
+
+    @property
+    def description(self) -> str:
+        return "Deep semantic search for research papers using Tavily API"
+
+    def execute(
+        self,
+        query: str,
+        max_results: int = 10,
+        filter_relevance: bool = True,
+        min_relevance_score: float = 0.5,
+    ) -> ToolResult:
+        """Execute deep search for research papers.
+
+        Args:
+            query: Search query (e.g., "momentum trading strategy")
+            max_results: Maximum number of results to return
+            filter_relevance: Use LLM to filter for implementable strategies
+            min_relevance_score: Minimum Tavily relevance score (0-1)
+
+        Returns:
+            ToolResult with list of relevant papers
+        """
+        self.logger.info(f"Deep searching for: {query}")
+
+        # Check Tavily configuration
+        tavily = TavilyClient()
+        if not tavily.is_configured():
+            return ToolResult(
+                success=False,
+                error="Tavily API key not configured. Set TAVILY_API_KEY in ~/.quantcoder/.env"
+            )
+
+        try:
+            # Search using Tavily
+            results = tavily.search_research_papers(query, max_results=max_results * 2)
+
+            if not results:
+                return ToolResult(
+                    success=False,
+                    error="No results found. Try a different query."
+                )
+
+            # Filter by minimum relevance score
+            results = [r for r in results if r.score >= min_relevance_score]
+
+            # Optionally filter for implementable strategies using LLM
+            if filter_relevance and results:
+                results = self._filter_for_implementable(results)
+
+            # Limit to requested max
+            results = results[:max_results]
+
+            if not results:
+                return ToolResult(
+                    success=False,
+                    error="No implementable trading strategies found in search results."
+                )
+
+            # Convert to article format compatible with existing workflow
+            articles = self._convert_to_articles(results)
+
+            # Save to articles.json for compatibility with download/summarize
+            self._save_articles_cache(articles)
+
+            return ToolResult(
+                success=True,
+                data=articles,
+                message=f"Found {len(articles)} relevant papers via deep search"
+            )
+
+        except Exception as e:
+            self.logger.error(f"Deep search failed: {e}")
+            return ToolResult(success=False, error=str(e))
+
+    def _filter_for_implementable(self, results: List[SearchResult]) -> List[SearchResult]:
+        """Filter results for papers with implementable trading strategies.
+
+        Uses LLM to analyze content and determine if the paper contains
+        a backtestable quantitative trading strategy.
+        """
+        try:
+            from ..core.llm import get_llm_provider
+            llm = get_llm_provider(self.config)
+        except Exception as e:
+            self.logger.warning(f"LLM not available for filtering: {e}")
+            return results
+
+        filtered = []
+
+        for result in results:
+            # Build prompt for relevance check
+            prompt = f"""Analyze this search result and determine if it describes an IMPLEMENTABLE quantitative trading strategy.
+
+Title: {result.title}
+Content: {result.content[:1000]}
+
+Answer with ONLY "YES" or "NO":
+- YES if the paper describes a specific, backtestable trading strategy with clear rules
+- NO if it's theoretical, survey-only, or doesn't describe a concrete strategy
+
+Answer:"""
+
+            try:
+                response = llm.generate(prompt, max_tokens=10)
+                is_relevant = "YES" in response.upper()
+
+                if is_relevant:
+                    filtered.append(result)
+                    self.logger.debug(f"Kept: {result.title}")
+                else:
+                    self.logger.debug(f"Filtered out: {result.title}")
+
+            except Exception as e:
+                self.logger.warning(f"LLM filter failed for {result.title}: {e}")
+                # Keep result if LLM fails
+                filtered.append(result)
+
+        return filtered
+
+    def _convert_to_articles(self, results: List[SearchResult]) -> List[Dict]:
+        """Convert SearchResults to article format compatible with existing workflow."""
+        articles = []
+
+        for result in results:
+            # Extract DOI if present in URL
+            doi = ""
+            if "doi.org" in result.url:
+                doi = result.url.split("doi.org/")[-1]
+            elif "arxiv.org" in result.url:
+                # Extract arxiv ID
+                doi = result.url.split("/")[-1]
+
+            article = {
+                "title": result.title,
+                "authors": "Unknown",  # Tavily doesn't always provide authors
+                "published": result.published_date or "",
+                "DOI": doi,
+                "URL": result.url,
+                "abstract": result.content,  # Use content as abstract
+                "relevance_score": result.score,
+                "source": "tavily_deep_search",
+            }
+            articles.append(article)
+
+        return articles
+
+    def _save_articles_cache(self, articles: List[Dict]):
+        """Save articles to cache file for compatibility with download/summarize."""
+        import json
+        from pathlib import Path
+
+        cache_file = Path(self.config.home_dir) / "articles.json"
+        cache_file.parent.mkdir(parents=True, exist_ok=True)
+
+        with open(cache_file, 'w') as f:
+            json.dump(articles, f, indent=4)
+
+        self.logger.info(f"Saved {len(articles)} articles to cache")

--- a/tests/test_deep_search.py
+++ b/tests/test_deep_search.py
@@ -1,0 +1,298 @@
+"""Tests for deep search using Tavily."""
+
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+from pathlib import Path
+
+from quantcoder.tools.deep_search import (
+    TavilyClient,
+    DeepSearchTool,
+    SearchResult,
+)
+
+
+class TestTavilyClient:
+    """Tests for TavilyClient."""
+
+    def test_is_configured_without_key(self):
+        """Test configuration check without API key."""
+        with patch.dict('os.environ', {}, clear=True):
+            client = TavilyClient(api_key=None)
+            assert not client.is_configured()
+
+    def test_is_configured_with_key(self):
+        """Test configuration check with API key."""
+        client = TavilyClient(api_key="test-key")
+        assert client.is_configured()
+
+    def test_is_configured_from_env(self):
+        """Test configuration from environment variable."""
+        with patch.dict('os.environ', {'TAVILY_API_KEY': 'env-key'}):
+            client = TavilyClient()
+            assert client.is_configured()
+            assert client.api_key == 'env-key'
+
+    @patch('requests.post')
+    def test_search_success(self, mock_post):
+        """Test successful search."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "results": [
+                {
+                    "title": "Momentum Trading Strategies",
+                    "url": "https://arxiv.org/abs/1234.5678",
+                    "content": "This paper presents a momentum strategy...",
+                    "score": 0.85,
+                    "published_date": "2024-01-15",
+                }
+            ]
+        }
+        mock_response.raise_for_status = Mock()
+        mock_post.return_value = mock_response
+
+        client = TavilyClient(api_key="test-key")
+        results = client.search("momentum trading")
+
+        assert len(results) == 1
+        assert results[0].title == "Momentum Trading Strategies"
+        assert results[0].score == 0.85
+
+    @patch('requests.post')
+    def test_search_no_api_key(self, mock_post):
+        """Test search without API key."""
+        with patch.dict('os.environ', {}, clear=True):
+            client = TavilyClient(api_key=None)
+            results = client.search("momentum")
+
+            assert results == []
+            mock_post.assert_not_called()
+
+    @patch('requests.post')
+    def test_search_api_error(self, mock_post):
+        """Test search with API error."""
+        import requests
+        mock_post.side_effect = requests.exceptions.RequestException("API Error")
+
+        client = TavilyClient(api_key="test-key")
+        results = client.search("momentum")
+
+        assert results == []
+
+    @patch('requests.post')
+    def test_search_research_papers(self, mock_post):
+        """Test research paper specific search."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"results": []}
+        mock_response.raise_for_status = Mock()
+        mock_post.return_value = mock_response
+
+        client = TavilyClient(api_key="test-key")
+        client.search_research_papers("factor investing")
+
+        # Check that academic domains are included
+        call_args = mock_post.call_args
+        payload = call_args[1]['json']
+        assert "arxiv.org" in payload.get('include_domains', [])
+        assert "ssrn.com" in payload.get('include_domains', [])
+
+
+class TestSearchResult:
+    """Tests for SearchResult dataclass."""
+
+    def test_to_dict(self):
+        """Test conversion to dict."""
+        result = SearchResult(
+            title="Test Paper",
+            url="https://example.com/paper",
+            content="Test content",
+            score=0.75,
+            published_date="2024-01-01"
+        )
+
+        d = result.to_dict()
+        assert d['title'] == "Test Paper"
+        assert d['score'] == 0.75
+        assert d['published_date'] == "2024-01-01"
+
+
+class TestDeepSearchTool:
+    """Tests for DeepSearchTool."""
+
+    @pytest.fixture
+    def mock_config(self, tmp_path):
+        """Create a mock config."""
+        config = Mock()
+        config.home_dir = tmp_path
+        return config
+
+    def test_tool_name(self, mock_config):
+        """Test tool name property."""
+        tool = DeepSearchTool(mock_config)
+        assert tool.name == "deep_search"
+
+    def test_tool_description(self, mock_config):
+        """Test tool description property."""
+        tool = DeepSearchTool(mock_config)
+        assert "Tavily" in tool.description
+
+    @patch.object(TavilyClient, 'is_configured', return_value=False)
+    def test_execute_no_api_key(self, mock_configured, mock_config):
+        """Test execution without API key."""
+        tool = DeepSearchTool(mock_config)
+        result = tool.execute("momentum")
+
+        assert not result.success
+        assert "TAVILY_API_KEY" in result.error
+
+    @patch.object(TavilyClient, 'search_research_papers')
+    @patch.object(TavilyClient, 'is_configured', return_value=True)
+    def test_execute_no_results(self, mock_configured, mock_search, mock_config):
+        """Test execution with no results."""
+        mock_search.return_value = []
+
+        tool = DeepSearchTool(mock_config)
+        result = tool.execute("obscure query xyz")
+
+        assert not result.success
+        assert "No results" in result.error
+
+    @patch.object(TavilyClient, 'search_research_papers')
+    @patch.object(TavilyClient, 'is_configured', return_value=True)
+    def test_execute_success(self, mock_configured, mock_search, mock_config):
+        """Test successful execution."""
+        mock_search.return_value = [
+            SearchResult(
+                title="Momentum Paper",
+                url="https://arxiv.org/test",
+                content="Trading strategy content",
+                score=0.8,
+            )
+        ]
+
+        tool = DeepSearchTool(mock_config)
+        result = tool.execute("momentum", filter_relevance=False)
+
+        assert result.success
+        assert len(result.data) == 1
+        assert result.data[0]['title'] == "Momentum Paper"
+
+    @patch.object(TavilyClient, 'search_research_papers')
+    @patch.object(TavilyClient, 'is_configured', return_value=True)
+    def test_execute_filters_low_score(self, mock_configured, mock_search, mock_config):
+        """Test that low-score results are filtered."""
+        mock_search.return_value = [
+            SearchResult(title="High Score", url="https://test1.com", content="Good", score=0.8),
+            SearchResult(title="Low Score", url="https://test2.com", content="Bad", score=0.3),
+        ]
+
+        tool = DeepSearchTool(mock_config)
+        result = tool.execute("test", filter_relevance=False, min_relevance_score=0.5)
+
+        assert result.success
+        assert len(result.data) == 1
+        assert result.data[0]['title'] == "High Score"
+
+    @patch.object(TavilyClient, 'search_research_papers')
+    @patch.object(TavilyClient, 'is_configured', return_value=True)
+    def test_execute_saves_cache(self, mock_configured, mock_search, mock_config):
+        """Test that results are saved to articles.json."""
+        mock_search.return_value = [
+            SearchResult(title="Test", url="https://test.com", content="Content", score=0.9)
+        ]
+
+        tool = DeepSearchTool(mock_config)
+        result = tool.execute("test", filter_relevance=False)
+
+        assert result.success
+        cache_file = mock_config.home_dir / "articles.json"
+        assert cache_file.exists()
+
+    @patch.object(TavilyClient, 'search_research_papers')
+    @patch.object(TavilyClient, 'is_configured', return_value=True)
+    def test_convert_to_articles_format(self, mock_configured, mock_search, mock_config):
+        """Test conversion to standard article format."""
+        mock_search.return_value = [
+            SearchResult(
+                title="ArXiv Paper",
+                url="https://arxiv.org/abs/2401.12345",
+                content="Abstract text",
+                score=0.85,
+                published_date="2024-01-15"
+            )
+        ]
+
+        tool = DeepSearchTool(mock_config)
+        result = tool.execute("test", filter_relevance=False)
+
+        assert result.success
+        article = result.data[0]
+        assert article['title'] == "ArXiv Paper"
+        assert article['URL'] == "https://arxiv.org/abs/2401.12345"
+        assert article['abstract'] == "Abstract text"
+        assert article['relevance_score'] == 0.85
+        assert article['source'] == "tavily_deep_search"
+
+
+class TestLLMFiltering:
+    """Tests for LLM-based relevance filtering."""
+
+    @pytest.fixture
+    def mock_config(self, tmp_path):
+        """Create a mock config."""
+        config = Mock()
+        config.home_dir = tmp_path
+        return config
+
+    @patch.object(DeepSearchTool, '_filter_for_implementable')
+    @patch.object(TavilyClient, 'search_research_papers')
+    @patch.object(TavilyClient, 'is_configured', return_value=True)
+    def test_llm_filter_keeps_relevant(self, mock_configured, mock_search, mock_filter, mock_config):
+        """Test LLM filter keeps relevant papers."""
+        test_results = [
+            SearchResult(title="Good Paper", url="https://test.com", content="Strategy", score=0.8)
+        ]
+        mock_search.return_value = test_results
+        # Mock filter to return same results (all kept)
+        mock_filter.return_value = test_results
+
+        tool = DeepSearchTool(mock_config)
+        result = tool.execute("test", filter_relevance=True)
+
+        assert result.success
+        assert len(result.data) == 1
+        mock_filter.assert_called_once()
+
+    @patch.object(DeepSearchTool, '_filter_for_implementable')
+    @patch.object(TavilyClient, 'search_research_papers')
+    @patch.object(TavilyClient, 'is_configured', return_value=True)
+    def test_llm_filter_removes_irrelevant(self, mock_configured, mock_search, mock_filter, mock_config):
+        """Test LLM filter removes irrelevant papers."""
+        mock_search.return_value = [
+            SearchResult(title="Bad Paper", url="https://test.com", content="Not a strategy", score=0.8)
+        ]
+        # Mock filter to return empty list (all filtered out)
+        mock_filter.return_value = []
+
+        tool = DeepSearchTool(mock_config)
+        result = tool.execute("test", filter_relevance=True)
+
+        # Should fail because all results filtered out
+        assert not result.success
+        assert "No implementable" in result.error
+
+    @patch.object(TavilyClient, 'search_research_papers')
+    @patch.object(TavilyClient, 'is_configured', return_value=True)
+    def test_filter_skipped_when_disabled(self, mock_configured, mock_search, mock_config):
+        """Test that filter is skipped when filter_relevance=False."""
+        mock_search.return_value = [
+            SearchResult(title="Paper", url="https://test.com", content="Content", score=0.8)
+        ]
+
+        tool = DeepSearchTool(mock_config)
+        # With filter_relevance=False, should not call LLM
+        result = tool.execute("test", filter_relevance=False)
+
+        assert result.success
+        assert len(result.data) == 1

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,369 @@
+"""Tests for centralized logging and monitoring."""
+
+import json
+import logging
+import pytest
+from pathlib import Path
+from unittest.mock import Mock, patch, MagicMock
+from datetime import datetime
+
+from quantcoder.logging_config import (
+    LoggingConfig,
+    JSONFormatter,
+    WebhookHandler,
+    QuantCoderLogger,
+    setup_logging,
+    get_logger,
+    get_log_files,
+    log_with_context,
+)
+from quantcoder.config import Config, LoggingConfigSettings
+
+
+class TestLoggingConfig:
+    """Tests for LoggingConfig dataclass."""
+
+    def test_default_values(self):
+        """Test default configuration values."""
+        config = LoggingConfig()
+        assert config.level == "INFO"
+        assert config.format == "standard"
+        assert config.max_file_size_mb == 10
+        assert config.backup_count == 5
+        assert config.alert_on_error is False
+
+    def test_custom_values(self):
+        """Test custom configuration values."""
+        config = LoggingConfig(
+            level="DEBUG",
+            format="json",
+            max_file_size_mb=20,
+            backup_count=10,
+            alert_on_error=True,
+            webhook_url="https://example.com/webhook",
+        )
+        assert config.level == "DEBUG"
+        assert config.format == "json"
+        assert config.max_file_size_mb == 20
+        assert config.webhook_url == "https://example.com/webhook"
+
+
+class TestJSONFormatter:
+    """Tests for JSON log formatter."""
+
+    def test_format_basic_record(self):
+        """Test formatting a basic log record."""
+        formatter = JSONFormatter()
+        record = logging.LogRecord(
+            name="test.module",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=42,
+            msg="Test message",
+            args=(),
+            exc_info=None,
+        )
+
+        output = formatter.format(record)
+        data = json.loads(output)
+
+        assert data["level"] == "INFO"
+        assert data["logger"] == "test.module"
+        assert data["message"] == "Test message"
+        assert data["line"] == 42
+        assert "timestamp" in data
+
+    def test_format_with_exception(self):
+        """Test formatting a record with exception info."""
+        formatter = JSONFormatter()
+
+        try:
+            raise ValueError("Test error")
+        except ValueError:
+            import sys
+            exc_info = sys.exc_info()
+
+        record = logging.LogRecord(
+            name="test.module",
+            level=logging.ERROR,
+            pathname="test.py",
+            lineno=42,
+            msg="Error occurred",
+            args=(),
+            exc_info=exc_info,
+        )
+
+        output = formatter.format(record)
+        data = json.loads(output)
+
+        assert data["level"] == "ERROR"
+        assert "exception" in data
+        assert "ValueError" in data["exception"]
+
+
+class TestWebhookHandler:
+    """Tests for webhook alerting handler."""
+
+    def test_handler_filters_by_level(self):
+        """Test that handler only sends alerts for configured levels."""
+        handler = WebhookHandler(
+            webhook_url="https://example.com/webhook",
+            alert_levels=["ERROR", "CRITICAL"]
+        )
+
+        # INFO should not trigger webhook
+        info_record = logging.LogRecord(
+            name="test", level=logging.INFO, pathname="", lineno=0,
+            msg="Info message", args=(), exc_info=None
+        )
+        with patch('requests.post') as mock_post:
+            handler.emit(info_record)
+            mock_post.assert_not_called()
+
+    @patch('requests.post')
+    def test_handler_sends_error_alerts(self, mock_post):
+        """Test that handler sends alerts for ERROR level."""
+        mock_post.return_value = Mock(status_code=200)
+
+        handler = WebhookHandler(
+            webhook_url="https://example.com/webhook",
+            alert_levels=["ERROR", "CRITICAL"]
+        )
+
+        error_record = logging.LogRecord(
+            name="test.module", level=logging.ERROR, pathname="test.py",
+            lineno=42, msg="Error occurred", args=(), exc_info=None
+        )
+        handler.emit(error_record)
+
+        mock_post.assert_called_once()
+        call_args = mock_post.call_args
+        payload = call_args[1]['json']
+
+        assert payload['level'] == 'ERROR'
+        assert payload['message'] == 'Error occurred'
+        assert payload['logger'] == 'test.module'
+
+    @patch('requests.post')
+    def test_handler_handles_webhook_failure(self, mock_post):
+        """Test that webhook failures don't break logging."""
+        mock_post.side_effect = Exception("Network error")
+
+        handler = WebhookHandler(
+            webhook_url="https://example.com/webhook",
+            alert_levels=["ERROR"]
+        )
+
+        error_record = logging.LogRecord(
+            name="test", level=logging.ERROR, pathname="", lineno=0,
+            msg="Error", args=(), exc_info=None
+        )
+
+        # Should not raise exception
+        handler.emit(error_record)
+
+
+class TestQuantCoderLogger:
+    """Tests for centralized logger manager."""
+
+    def test_singleton_pattern(self):
+        """Test that QuantCoderLogger uses singleton pattern."""
+        logger1 = QuantCoderLogger()
+        logger2 = QuantCoderLogger()
+        assert logger1 is logger2
+
+    def test_setup_creates_handlers(self, tmp_path):
+        """Test that setup creates file handlers."""
+        config = LoggingConfig(log_dir=tmp_path)
+
+        # Reset singleton state for test
+        QuantCoderLogger._initialized = False
+        logger_manager = QuantCoderLogger()
+        logger_manager.setup(verbose=False, config=config)
+
+        # Check log files are created
+        log_file = tmp_path / "quantcoder.log"
+        json_log_file = tmp_path / "quantcoder.json.log"
+
+        # Write a log message to create files
+        test_logger = logging.getLogger("quantcoder.test")
+        test_logger.info("Test message")
+
+        assert log_file.exists() or json_log_file.exists()
+
+        # Cleanup
+        logger_manager.cleanup()
+
+
+class TestGetLogger:
+    """Tests for get_logger function."""
+
+    def test_returns_logger_with_namespace(self):
+        """Test that get_logger returns properly namespaced logger."""
+        logger = get_logger("mymodule")
+        assert logger.name == "quantcoder.mymodule"
+
+    def test_already_namespaced_logger(self):
+        """Test that already namespaced logger is not double-prefixed."""
+        logger = get_logger("quantcoder.existing")
+        assert logger.name == "quantcoder.existing"
+
+
+class TestConfigLoggingSettings:
+    """Tests for Config logging settings integration."""
+
+    def test_config_has_logging_settings(self):
+        """Test that Config includes logging settings."""
+        config = Config()
+        assert hasattr(config, 'logging')
+        assert isinstance(config.logging, LoggingConfigSettings)
+
+    def test_logging_settings_defaults(self):
+        """Test default logging settings in Config."""
+        config = Config()
+        assert config.logging.level == "INFO"
+        assert config.logging.format == "standard"
+        assert config.logging.max_file_size_mb == 10
+        assert config.logging.backup_count == 5
+
+    def test_config_to_dict_includes_logging(self):
+        """Test that to_dict includes logging config."""
+        config = Config()
+        data = config.to_dict()
+
+        assert "logging" in data
+        assert data["logging"]["level"] == "INFO"
+        assert data["logging"]["format"] == "standard"
+
+    def test_config_from_dict_with_logging(self):
+        """Test that from_dict loads logging config."""
+        data = {
+            "logging": {
+                "level": "DEBUG",
+                "format": "json",
+                "max_file_size_mb": 25,
+                "backup_count": 15,
+                "alert_on_error": True,
+                "webhook_url": "https://test.com",
+                "alert_levels": ["ERROR"],
+            }
+        }
+
+        config = Config.from_dict(data)
+        assert config.logging.level == "DEBUG"
+        assert config.logging.format == "json"
+        assert config.logging.max_file_size_mb == 25
+        assert config.logging.alert_on_error is True
+
+    def test_get_logging_config_method(self, tmp_path):
+        """Test get_logging_config returns LoggingConfig object."""
+        # Mock dotenv module
+        import sys
+        mock_dotenv = MagicMock()
+        original_dotenv = sys.modules.get('dotenv')
+        sys.modules['dotenv'] = mock_dotenv
+
+        try:
+            config = Config()
+            config.home_dir = tmp_path
+            config.logging.level = "DEBUG"
+            config.logging.format = "json"
+
+            with patch.dict('os.environ', {}, clear=True):
+                logging_config = config.get_logging_config()
+
+            assert logging_config.level == "DEBUG"
+            assert logging_config.format == "json"
+            assert logging_config.log_dir == tmp_path / "logs"
+        finally:
+            # Restore original dotenv
+            if original_dotenv:
+                sys.modules['dotenv'] = original_dotenv
+            else:
+                sys.modules.pop('dotenv', None)
+
+
+class TestAutoStatsPersistence:
+    """Tests for AutoStats persistence."""
+
+    def test_autostats_to_dict(self):
+        """Test AutoStats serialization."""
+        from quantcoder.autonomous.pipeline import AutoStats
+
+        stats = AutoStats(
+            total_attempts=10,
+            successful=7,
+            failed=3,
+            avg_sharpe=1.5,
+        )
+
+        data = stats.to_dict()
+        assert data['total_attempts'] == 10
+        assert data['successful'] == 7
+        assert data['failed'] == 3
+        assert data['avg_sharpe'] == 1.5
+        assert 'session_id' in data
+        assert 'last_updated' in data
+
+    def test_autostats_from_dict(self):
+        """Test AutoStats deserialization."""
+        from quantcoder.autonomous.pipeline import AutoStats
+
+        data = {
+            'total_attempts': 5,
+            'successful': 4,
+            'failed': 1,
+            'avg_sharpe': 2.0,
+            'session_id': 'test_session',
+        }
+
+        stats = AutoStats.from_dict(data)
+        assert stats.total_attempts == 5
+        assert stats.successful == 4
+        assert stats.session_id == 'test_session'
+
+    def test_autostats_save_load(self, tmp_path):
+        """Test saving and loading AutoStats."""
+        from quantcoder.autonomous.pipeline import AutoStats
+
+        stats = AutoStats(
+            total_attempts=10,
+            successful=8,
+            failed=2,
+        )
+        stats.save(tmp_path)
+
+        # Check file exists
+        assert (tmp_path / f"auto_stats_{stats.session_id}.json").exists()
+        assert (tmp_path / "auto_stats_latest.json").exists()
+
+        # Load and verify
+        loaded = AutoStats.load_latest(tmp_path)
+        assert loaded is not None
+        assert loaded.total_attempts == 10
+        assert loaded.successful == 8
+
+    def test_autostats_list_sessions(self, tmp_path):
+        """Test listing AutoStats sessions."""
+        from quantcoder.autonomous.pipeline import AutoStats
+        import time
+
+        # Create multiple sessions
+        for i in range(3):
+            stats = AutoStats(total_attempts=i * 10)
+            stats.session_id = f"session_{i}"
+            stats.save(tmp_path)
+            time.sleep(0.01)  # Small delay to ensure different mtimes
+
+        sessions = AutoStats.list_sessions(tmp_path)
+        assert len(sessions) == 3
+
+    def test_autostats_success_rate(self):
+        """Test success rate calculation."""
+        from quantcoder.autonomous.pipeline import AutoStats
+
+        stats = AutoStats(total_attempts=10, successful=7, failed=3)
+        assert stats.success_rate == 0.7
+
+        empty_stats = AutoStats()
+        assert empty_stats.success_rate == 0.0

--- a/tests/test_multi_article.py
+++ b/tests/test_multi_article.py
@@ -1,0 +1,278 @@
+"""Tests for multi-article workflow with consolidated summaries."""
+
+import pytest
+import json
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from quantcoder.core.summary_store import (
+    SummaryStore,
+    IndividualSummary,
+    ConsolidatedSummary
+)
+
+
+class TestSummaryStore:
+    """Tests for SummaryStore."""
+
+    @pytest.fixture
+    def store(self, tmp_path):
+        """Create a temporary summary store."""
+        return SummaryStore(tmp_path)
+
+    @pytest.fixture
+    def sample_individual(self):
+        """Create a sample individual summary."""
+        return IndividualSummary(
+            article_id=1,
+            title="Momentum Trading Strategies",
+            authors="John Doe",
+            url="https://example.com/paper1",
+            strategy_type="momentum",
+            key_concepts=["12-month lookback", "monthly rebalance"],
+            indicators=["SMA", "RSI"],
+            risk_approach="volatility targeting",
+            summary_text="This paper presents a momentum strategy..."
+        )
+
+    def test_save_individual_summary(self, store, sample_individual):
+        """Test saving an individual summary."""
+        summary_id = store.save_individual(sample_individual)
+
+        assert summary_id == 1
+        assert store.get_summary_id_for_article(1) == 1
+
+        # Retrieve and verify
+        saved = store.get_summary(summary_id)
+        assert saved is not None
+        assert saved['title'] == "Momentum Trading Strategies"
+        assert saved['is_consolidated'] is False
+
+    def test_save_consolidated_summary(self, store, sample_individual):
+        """Test saving a consolidated summary."""
+        # First save individual summaries
+        store.save_individual(sample_individual)
+
+        individual2 = IndividualSummary(
+            article_id=2,
+            title="Risk Management Techniques",
+            authors="Jane Smith",
+            url="https://example.com/paper2",
+            strategy_type="risk_management",
+            key_concepts=["stop loss", "position sizing"],
+            indicators=["ATR"],
+            risk_approach="fixed fractional",
+            summary_text="This paper presents risk management..."
+        )
+        store.save_individual(individual2)
+
+        # Create consolidated
+        consolidated = ConsolidatedSummary(
+            summary_id=0,
+            source_article_ids=[1, 2],
+            references=[
+                {"id": 1, "title": "Momentum Trading", "contribution": "signals"},
+                {"id": 2, "title": "Risk Management", "contribution": "risk"}
+            ],
+            merged_strategy_type="hybrid",
+            merged_description="Combined momentum and risk management",
+            contributions_by_article={1: "momentum signals", 2: "risk management"},
+            key_concepts=["momentum", "risk"],
+            indicators=["SMA", "ATR"],
+            risk_approach="Combined approach"
+        )
+
+        consolidated_id = store.save_consolidated(consolidated)
+
+        assert consolidated_id == 3  # After 2 individual summaries
+        assert store.is_consolidated(consolidated_id)
+
+        # Retrieve and verify
+        saved = store.get_summary(consolidated_id)
+        assert saved is not None
+        assert saved['source_article_ids'] == [1, 2]
+        assert saved['is_consolidated'] is True
+
+    def test_list_summaries(self, store, sample_individual):
+        """Test listing all summaries."""
+        store.save_individual(sample_individual)
+
+        summaries = store.list_summaries()
+
+        assert len(summaries['individual']) == 1
+        assert len(summaries['consolidated']) == 0
+        assert summaries['individual'][0]['article_id'] == 1
+
+    def test_get_individual_summaries(self, store, sample_individual):
+        """Test getting multiple individual summaries."""
+        store.save_individual(sample_individual)
+
+        individual2 = IndividualSummary(
+            article_id=2,
+            title="Paper 2",
+            authors="Author",
+            url="",
+            strategy_type="other",
+            key_concepts=[],
+            indicators=[],
+            risk_approach="",
+            summary_text="Summary 2"
+        )
+        store.save_individual(individual2)
+
+        summaries = store.get_individual_summaries([1, 2])
+        assert len(summaries) == 2
+
+
+class TestMultiArticleWorkflow:
+    """Tests for the multi-article workflow integration."""
+
+    @pytest.fixture
+    def mock_config(self, tmp_path):
+        """Create a mock config."""
+        config = Mock()
+        config.home_dir = tmp_path
+        config.tools.downloads_dir = str(tmp_path / "downloads")
+        config.tools.generated_code_dir = str(tmp_path / "generated")
+
+        # Create directories
+        (tmp_path / "downloads").mkdir()
+        (tmp_path / "generated").mkdir()
+
+        return config
+
+    def test_workflow_single_article(self, mock_config, tmp_path):
+        """Test workflow with single article."""
+        # Create articles.json
+        articles = [{"title": "Test Paper", "authors": "Author", "URL": "http://test.com"}]
+        with open(tmp_path / "articles.json", 'w') as f:
+            json.dump(articles, f)
+
+        store = SummaryStore(tmp_path)
+
+        # Simulate creating individual summary
+        individual = IndividualSummary(
+            article_id=1,
+            title="Test Paper",
+            authors="Author",
+            url="http://test.com",
+            strategy_type="momentum",
+            key_concepts=["test"],
+            indicators=["SMA"],
+            risk_approach="basic",
+            summary_text="Test summary"
+        )
+        summary_id = store.save_individual(individual)
+
+        # Verify we can retrieve it
+        summary = store.get_summary(summary_id)
+        assert summary is not None
+        assert summary['article_id'] == 1
+
+    def test_workflow_multiple_articles_creates_consolidated(self, mock_config, tmp_path):
+        """Test that multiple articles create a consolidated summary."""
+        store = SummaryStore(tmp_path)
+
+        # Create two individual summaries
+        for i in [1, 2]:
+            individual = IndividualSummary(
+                article_id=i,
+                title=f"Paper {i}",
+                authors="Author",
+                url=f"http://test{i}.com",
+                strategy_type="momentum" if i == 1 else "risk_management",
+                key_concepts=[f"concept{i}"],
+                indicators=["SMA"] if i == 1 else ["ATR"],
+                risk_approach="basic",
+                summary_text=f"Summary for paper {i}"
+            )
+            store.save_individual(individual)
+
+        # Create consolidated
+        consolidated = ConsolidatedSummary(
+            summary_id=0,
+            source_article_ids=[1, 2],
+            references=[
+                {"id": 1, "title": "Paper 1", "contribution": "momentum"},
+                {"id": 2, "title": "Paper 2", "contribution": "risk"}
+            ],
+            merged_strategy_type="hybrid",
+            merged_description="Combined strategy",
+            contributions_by_article={1: "signals", 2: "risk"},
+            key_concepts=["concept1", "concept2"],
+            indicators=["SMA", "ATR"],
+            risk_approach="combined"
+        )
+        consolidated_id = store.save_consolidated(consolidated)
+
+        # Verify
+        assert consolidated_id == 3
+        summaries = store.list_summaries()
+        assert len(summaries['individual']) == 2
+        assert len(summaries['consolidated']) == 1
+        assert summaries['consolidated'][0]['source_article_ids'] == [1, 2]
+
+
+class TestIndividualSummary:
+    """Tests for IndividualSummary dataclass."""
+
+    def test_to_dict(self):
+        """Test conversion to dict."""
+        summary = IndividualSummary(
+            article_id=1,
+            title="Test",
+            authors="Author",
+            url="http://test.com",
+            strategy_type="momentum",
+            key_concepts=["a", "b"],
+            indicators=["SMA"],
+            risk_approach="basic",
+            summary_text="Summary"
+        )
+
+        d = summary.to_dict()
+        assert d['article_id'] == 1
+        assert d['title'] == "Test"
+        assert d['key_concepts'] == ["a", "b"]
+
+    def test_from_dict(self):
+        """Test creation from dict."""
+        data = {
+            "article_id": 1,
+            "title": "Test",
+            "authors": "Author",
+            "url": "http://test.com",
+            "strategy_type": "momentum",
+            "key_concepts": ["a"],
+            "indicators": ["SMA"],
+            "risk_approach": "basic",
+            "summary_text": "Summary",
+            "created_at": "2024-01-01T00:00:00"
+        }
+
+        summary = IndividualSummary.from_dict(data)
+        assert summary.article_id == 1
+        assert summary.title == "Test"
+
+
+class TestConsolidatedSummary:
+    """Tests for ConsolidatedSummary dataclass."""
+
+    def test_to_dict(self):
+        """Test conversion to dict."""
+        summary = ConsolidatedSummary(
+            summary_id=5,
+            source_article_ids=[1, 2, 3],
+            references=[{"id": 1, "title": "P1", "contribution": "c1"}],
+            merged_strategy_type="hybrid",
+            merged_description="Combined",
+            contributions_by_article={1: "signals"},
+            key_concepts=["a"],
+            indicators=["SMA"],
+            risk_approach="combined"
+        )
+
+        d = summary.to_dict()
+        assert d['summary_id'] == 5
+        assert d['source_article_ids'] == [1, 2, 3]
+        assert d['is_consolidated'] is True

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -234,6 +234,6 @@ class TestPipelineConfig:
         config = PipelineConfig()
 
         assert len(config.search_queries) > 0
-        assert config.min_sharpe_ratio == 0.5
-        assert config.max_strategies_per_run == 3
+        assert config.min_sharpe_ratio == 0.5  # Acceptance criteria
+        assert config.max_strategies_per_run == 10  # Batch limit
         assert config.publish_to_notion is True

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,239 @@
+"""Tests for the scheduler module."""
+
+import pytest
+from unittest.mock import Mock, AsyncMock, patch
+from datetime import datetime
+from pathlib import Path
+
+from quantcoder.scheduler.notion_client import NotionClient, StrategyArticle
+from quantcoder.scheduler.article_generator import ArticleGenerator, StrategyReport
+from quantcoder.scheduler.runner import ScheduledRunner, ScheduleConfig, ScheduleInterval
+
+
+class TestNotionClient:
+    """Tests for NotionClient."""
+
+    def test_is_configured_without_credentials(self):
+        """Test is_configured returns False without credentials."""
+        client = NotionClient(api_key=None, database_id=None)
+        assert not client.is_configured()
+
+    def test_is_configured_with_credentials(self):
+        """Test is_configured returns True with credentials."""
+        client = NotionClient(api_key="test_key", database_id="test_db")
+        assert client.is_configured()
+
+    @patch('requests.get')
+    def test_test_connection_success(self, mock_get):
+        """Test successful connection test."""
+        mock_get.return_value.status_code = 200
+        client = NotionClient(api_key="test_key", database_id="test_db")
+        assert client.test_connection()
+
+    @patch('requests.get')
+    def test_test_connection_failure(self, mock_get):
+        """Test failed connection test."""
+        mock_get.return_value.status_code = 401
+        client = NotionClient(api_key="invalid_key", database_id="test_db")
+        assert not client.test_connection()
+
+
+class TestStrategyArticle:
+    """Tests for StrategyArticle."""
+
+    def test_to_notion_blocks(self):
+        """Test conversion to Notion blocks."""
+        article = StrategyArticle(
+            title="Test Strategy",
+            paper_title="Test Paper",
+            paper_url="https://example.com/paper",
+            paper_authors=["Author 1", "Author 2"],
+            strategy_summary="This is a test strategy.",
+            strategy_type="momentum",
+            backtest_results={
+                "sharpe_ratio": 1.5,
+                "total_return": 0.25,
+                "max_drawdown": -0.10,
+            },
+            tags=["momentum", "high sharpe"],
+        )
+
+        blocks = article.to_notion_blocks()
+
+        assert len(blocks) > 0
+        # Check for callout block with paper info
+        assert any(b.get("type") == "callout" for b in blocks)
+        # Check for heading blocks
+        assert any(b.get("type") == "heading_2" for b in blocks)
+
+
+class TestArticleGenerator:
+    """Tests for ArticleGenerator."""
+
+    @pytest.fixture
+    def sample_report(self):
+        """Create a sample strategy report."""
+        return StrategyReport(
+            strategy_name="MomentumStrategy_20240101",
+            paper_title="A Study of Momentum Trading",
+            paper_url="https://arxiv.org/abs/1234.5678",
+            paper_authors=["John Doe", "Jane Smith"],
+            paper_abstract="This paper studies momentum trading strategies...",
+            strategy_type="momentum",
+            strategy_summary="",
+            code_files={
+                "Main.py": "class MomentumAlgorithm(QCAlgorithm):\n    pass",
+                "Alpha.py": "class MomentumAlpha:\n    pass",
+            },
+            backtest_results={
+                "sharpe_ratio": 1.2,
+                "total_return": 0.35,
+                "max_drawdown": -0.15,
+            },
+        )
+
+    def test_generate_title(self, sample_report):
+        """Test title generation."""
+        generator = ArticleGenerator()
+        title = generator.generate_title(sample_report)
+
+        assert "Momentum" in title
+        assert sample_report.strategy_name in title
+
+    def test_generate_template_summary(self, sample_report):
+        """Test template-based summary generation."""
+        generator = ArticleGenerator()
+        summary = generator._generate_template_summary(sample_report)
+
+        assert len(summary) > 0
+        assert "momentum" in summary.lower()
+        assert "1.2" in summary or "Sharpe" in summary
+
+    def test_generate_notion_article(self, sample_report):
+        """Test Notion article generation."""
+        generator = ArticleGenerator()
+        article = generator.generate_notion_article(sample_report)
+
+        assert isinstance(article, StrategyArticle)
+        assert article.paper_title == sample_report.paper_title
+        assert article.strategy_type == "momentum"
+        assert len(article.tags) > 0
+
+    def test_generate_markdown(self, sample_report):
+        """Test markdown generation."""
+        generator = ArticleGenerator()
+        markdown = generator.generate_markdown(sample_report)
+
+        assert "# " in markdown
+        assert sample_report.paper_title in markdown
+        assert "```python" in markdown
+        assert "Sharpe Ratio" in markdown
+
+
+class TestScheduleConfig:
+    """Tests for ScheduleConfig."""
+
+    def test_daily_trigger(self):
+        """Test daily schedule trigger creation."""
+        config = ScheduleConfig(
+            interval=ScheduleInterval.DAILY,
+            hour=6,
+            minute=0,
+        )
+        trigger = config.to_trigger()
+        assert trigger is not None
+
+    def test_weekly_trigger(self):
+        """Test weekly schedule trigger creation."""
+        config = ScheduleConfig(
+            interval=ScheduleInterval.WEEKLY,
+            hour=9,
+            day_of_week="mon",
+        )
+        trigger = config.to_trigger()
+        assert trigger is not None
+
+    def test_hourly_trigger(self):
+        """Test hourly schedule trigger creation."""
+        config = ScheduleConfig(interval=ScheduleInterval.HOURLY)
+        trigger = config.to_trigger()
+        assert trigger is not None
+
+
+class TestScheduledRunner:
+    """Tests for ScheduledRunner."""
+
+    @pytest.fixture
+    def mock_pipeline(self):
+        """Create a mock pipeline function."""
+        async def pipeline():
+            return {"strategies_generated": 2, "strategies_published": 1}
+        return pipeline
+
+    def test_runner_initialization(self, mock_pipeline, tmp_path):
+        """Test runner initialization."""
+        runner = ScheduledRunner(
+            pipeline_func=mock_pipeline,
+            state_file=tmp_path / "test_state.json"
+        )
+        assert runner.stats.total_runs == 0
+        assert not runner.running
+
+    def test_get_status(self, mock_pipeline, tmp_path):
+        """Test status retrieval."""
+        runner = ScheduledRunner(
+            pipeline_func=mock_pipeline,
+            state_file=tmp_path / "test_state.json"
+        )
+        status = runner.get_status()
+
+        assert "running" in status
+        assert "stats" in status
+        assert status["running"] is False
+
+    @pytest.mark.asyncio
+    async def test_run_once(self, mock_pipeline, tmp_path):
+        """Test single run execution."""
+        runner = ScheduledRunner(
+            pipeline_func=mock_pipeline,
+            state_file=tmp_path / "test_state.json"
+        )
+        await runner.run_once()
+
+        assert runner.stats.total_runs == 1
+        assert runner.stats.successful_runs == 1
+        assert runner.stats.strategies_generated == 2
+        assert runner.stats.strategies_published == 1
+
+    @pytest.mark.asyncio
+    async def test_run_with_error(self, tmp_path):
+        """Test run with pipeline error."""
+        async def failing_pipeline():
+            raise ValueError("Test error")
+
+        # Use a separate state file to avoid test pollution
+        runner = ScheduledRunner(
+            pipeline_func=failing_pipeline,
+            state_file=tmp_path / "test_state.json"
+        )
+        await runner.run_once()
+
+        assert runner.stats.total_runs == 1
+        assert runner.stats.failed_runs == 1
+        assert runner.stats.successful_runs == 0
+        assert len(runner.stats.errors) == 1
+
+
+class TestPipelineConfig:
+    """Tests for PipelineConfig."""
+
+    def test_default_config(self):
+        """Test default configuration values."""
+        from quantcoder.scheduler.automated_pipeline import PipelineConfig
+
+        config = PipelineConfig()
+
+        assert len(config.search_queries) > 0
+        assert config.min_sharpe_ratio == 0.5
+        assert config.max_strategies_per_run == 3
+        assert config.publish_to_notion is True


### PR DESCRIPTION
Add a new scheduler module for fully automated strategy generation:
- NotionClient: Publish strategy articles to Notion databases
- ArticleGenerator: Generate formatted reports from backtest results
- ScheduledRunner: APScheduler-based job runner with persistence
- AutomatedBacktestPipeline: End-to-end workflow orchestration

New CLI commands:
- quantcoder schedule start: Start scheduled automation
- quantcoder schedule run: Run pipeline once manually
- quantcoder schedule status: View run statistics
- quantcoder schedule config: Configure Notion credentials

Features:
- Papers -> Backtest -> Best Strategy -> Notion workflow
- Algorithms kept in QuantConnect, articles published to Notion
- Configurable schedules (hourly, daily, weekly)
- Tracks processed papers to avoid duplicates
- Persistent state across restarts
- Min Sharpe thresholds for generation and publishing

https://claude.ai/code/session_01SwNvxUMWNQ3RYpdCNg38xY